### PR TITLE
Area Tests

### DIFF
--- a/src/ToolboxBundle/Builder/BrickConfigBuilder.php
+++ b/src/ToolboxBundle/Builder/BrickConfigBuilder.php
@@ -88,20 +88,36 @@ class BrickConfigBuilder
      * @param array $configNode
      * @param array $themeOptions
      *
-     * @return bool|string
+     * @return string
      * @throws \Exception
      */
-    public function buildElementConfig(
-        $documentEditableId,
-        $documentEditableName,
-        Info $info,
-        $configNode = [],
-        $themeOptions = []
-    ) {
+    public function buildElementConfig($documentEditableId, $documentEditableName, Info $info, $configNode = [], $themeOptions = [])
+    {
+        $fieldSetArgs = $this->buildElementConfigArguments($documentEditableId, $documentEditableName, $info, $configNode, $themeOptions);
+        
+        if(empty($fieldSetArgs)) {
+            return '';
+        }
+
+        return $this->templating->render('@Toolbox/Admin/AreaConfig/fieldSet.html.twig', $fieldSetArgs);
+    }
+
+    /**
+     * @param       $documentEditableId
+     * @param       $documentEditableName
+     * @param Info  $info
+     * @param array $configNode
+     * @param array $themeOptions
+     *
+     * @return array
+     * @throws \Exception
+     */
+    public function buildElementConfigArguments($documentEditableId, $documentEditableName, Info $info, $configNode = [], $themeOptions = [])
+    {
         $this->reset();
 
         if ($info->getView()->get('editmode') === false) {
-            return false;
+            return [];
         }
 
         $this->documentEditableId = $documentEditableId;
@@ -132,7 +148,7 @@ class BrickConfigBuilder
             'brick_id'               => $info->id
         ];
 
-        return $this->templating->render('@Toolbox/Admin/AreaConfig/fieldSet.html.twig', $fieldSetArgs);
+        return $fieldSetArgs;
     }
 
     /**

--- a/src/ToolboxBundle/Builder/BrickConfigBuilder.php
+++ b/src/ToolboxBundle/Builder/BrickConfigBuilder.php
@@ -87,11 +87,17 @@ class BrickConfigBuilder
      * @param Info  $info
      * @param array $configNode
      * @param array $themeOptions
+     *
      * @return bool|string
      * @throws \Exception
      */
-    public function buildElementConfig($documentEditableId, $documentEditableName, Info $info, $configNode = [], $themeOptions = [])
-    {
+    public function buildElementConfig(
+        $documentEditableId,
+        $documentEditableName,
+        Info $info,
+        $configNode = [],
+        $themeOptions = []
+    ) {
         $this->reset();
 
         if ($info->getView()->get('editmode') === false) {
@@ -140,6 +146,7 @@ class BrickConfigBuilder
 
     /**
      * @param $type
+     *
      * @return bool
      */
     private function needStore($type)
@@ -148,7 +155,18 @@ class BrickConfigBuilder
     }
 
     /**
+     * @param $parsedConfig
+     *
+     * @return bool
+     */
+    private function hasValidStore($parsedConfig)
+    {
+        return isset($parsedConfig['store']) && is_array($parsedConfig['store']) && count($parsedConfig['store']) > 0;
+    }
+
+    /**
      * @param $type
+     *
      * @return bool
      */
     private function canHaveDynamicWidth($type)
@@ -178,6 +196,7 @@ class BrickConfigBuilder
 
     /**
      * @param $type
+     *
      * @return bool
      */
     private function canHaveDynamicHeight($type)
@@ -216,6 +235,7 @@ class BrickConfigBuilder
      * @param $type
      * @param $config
      * @param $additionalConfig
+     *
      * @return array
      * @throws \Exception
      */
@@ -345,6 +365,7 @@ class BrickConfigBuilder
     /**
      * @param $configElementName
      * @param $elConf
+     *
      * @return mixed
      * @throws \Exception
      */
@@ -433,6 +454,11 @@ class BrickConfigBuilder
             $parsedAdditionalConfig = $this->getAdditionalConfig($configElementName, $c);
             $parsedTagConfig = $this->getTagConfig($c['type'], $tagConfig, $parsedAdditionalConfig);
 
+            //if element need's a store and store is empty: skip field
+            if ($this->needStore($c['type']) && $this->hasValidStore($parsedTagConfig) === false) {
+                continue;
+            }
+
             $parsedConfig[] = ['tag_config' => $parsedTagConfig, 'additional_config' => $parsedAdditionalConfig];
             $parsedConfig = $this->checkDependingSystemField($configElementName, $parsedConfig);
 
@@ -447,6 +473,7 @@ class BrickConfigBuilder
      *
      * @param $configElementName
      * @param $configFields
+     *
      * @return array
      */
     private function checkDependingSystemField($configElementName, $configFields)
@@ -474,6 +501,7 @@ class BrickConfigBuilder
 
     /**
      * @param $configElements
+     *
      * @return array
      */
     private function checkCondition($configElements)
@@ -556,7 +584,13 @@ class BrickConfigBuilder
     private function resetElement($el)
     {
         $value = !empty($el['tag_config']['default']) ? $el['tag_config']['default'] : null;
-        $this->tagRenderer->getTag($this->info->getDocument(), $el['additional_config']['type'], $el['additional_config']['name'])->setDataFromResource($value);
+
+        $this->tagRenderer->getTag(
+            $this->info->getDocument(),
+            $el['additional_config']['type'],
+            $el['additional_config']['name']
+        )->setDataFromResource($value);
+
         $el['additional_config']['selected_value'] = $value;
         $el['additional_config']['editmode_hidden'] = true;
 

--- a/src/ToolboxBundle/Command/AreaConfigurationCommand.php
+++ b/src/ToolboxBundle/Command/AreaConfigurationCommand.php
@@ -161,7 +161,7 @@ class AreaConfigurationCommand extends Command
      * @param int    $depth
      * @return string
      */
-    function parseArrayForOutput(array $array = [], $string = '', $depth = 0)
+    private function parseArrayForOutput(array $array = [], $string = '', $depth = 0)
     {
         $depthStr = str_repeat(' ', $depth * 3);
         foreach ($array as $key => $value) {

--- a/src/ToolboxBundle/DependencyInjection/Configuration.php
+++ b/src/ToolboxBundle/DependencyInjection/Configuration.php
@@ -27,7 +27,7 @@ class Configuration implements ConfigurationInterface
     /**
      * @param ArrayNodeDefinition $rootNode
      */
-    function addContextNode(ArrayNodeDefinition $rootNode)
+    public function addContextNode(ArrayNodeDefinition $rootNode)
     {
         $node = $rootNode
             ->children()
@@ -72,7 +72,7 @@ class Configuration implements ConfigurationInterface
      * @param ArrayNodeDefinition $rootNode
      * @param bool                $addContextSettings
      */
-    function getConfigNode(ArrayNodeDefinition $rootNode, $addContextSettings = true)
+    public function getConfigNode(ArrayNodeDefinition $rootNode, $addContextSettings = true)
     {
         //@todo: get them dynamically!!
         $allowedTypes = array_merge(ToolboxConfig::CORE_TYPES, ToolboxConfig::CUSTOM_TYPES);

--- a/src/ToolboxBundle/Document/Areabrick/AbstractAreabrick.php
+++ b/src/ToolboxBundle/Document/Areabrick/AbstractAreabrick.php
@@ -120,10 +120,12 @@ abstract class AbstractAreabrick extends AbstractTemplateAreabrick
         $layoutDir = null;
 
         $view = $info->getView();
-        $view->elementConfigBar = $configWindowData;
-        $view->additionalClassesData = $this->configureAdditionalClasses($info, $configNode);
-        $view->elementThemeConfig = $this->layoutManager->getAreaThemeConfig($this->getId());
-        $view->areaId = $this->getId();
+        $view->getParameters()->add([
+            'elementConfigBar'      => $configWindowData,
+            'additionalClassesData' => $this->configureAdditionalClasses($info, $configNode),
+            'elementThemeConfig'    => $this->layoutManager->getAreaThemeConfig($this->getId()),
+            'areaId'                => $this->getId()
+        ]);
     }
 
     /**

--- a/src/ToolboxBundle/Document/Areabrick/AbstractAreabrick.php
+++ b/src/ToolboxBundle/Document/Areabrick/AbstractAreabrick.php
@@ -203,7 +203,7 @@ abstract class AbstractAreabrick extends AbstractTemplateAreabrick
     public function getIcon()
     {
         if ($this->getAreaBrickType() == self::AREABRICK_TYPE_EXTERNAL) {
-            return false;
+            return null;
         }
 
         return '/bundles/toolbox/areas/' . $this->getId() . '/icon.svg';

--- a/src/ToolboxBundle/Document/Areabrick/Accordion/Accordion.php
+++ b/src/ToolboxBundle/Document/Areabrick/Accordion/Accordion.php
@@ -10,7 +10,15 @@ class Accordion extends AbstractAreabrick
     public function action(Info $info)
     {
         parent::action($info);
-        $info->getView()->id = uniqid('accordion-');
+
+        $infoParams = $info->getParams();
+        if (isset($infoParams['toolboxAccordionId'])) {
+            $id = $infoParams['toolboxAccordionId'];
+        } else {
+            $id = uniqid('accordion-');
+        }
+
+        $info->getView()->getParameters()->add(['id' => $id]);
     }
 
     public function getName()

--- a/src/ToolboxBundle/Document/Areabrick/Columns/Columns.php
+++ b/src/ToolboxBundle/Document/Areabrick/Columns/Columns.php
@@ -23,6 +23,7 @@ class Columns extends AbstractAreabrick
 
     /**
      * @param Info $info
+     *
      * @return null|\Symfony\Component\HttpFoundation\Response|void
      * @throws \Exception
      */
@@ -48,7 +49,9 @@ class Columns extends AbstractAreabrick
         }
 
         $theme = $this->configManager->getConfig('theme');
-        $columns = $this->calculatorRegistry->getColumnCalculator($theme['calculators']['column_calculator'])->calculateColumns($type, $customColumnConfiguration);
+        $columns = $this->calculatorRegistry
+            ->getColumnCalculator($theme['calculators']['column_calculator'])
+            ->calculateColumns($type, $customColumnConfiguration);
 
         if (!empty($columns)) {
 
@@ -64,11 +67,12 @@ class Columns extends AbstractAreabrick
             }
         }
 
-        $view->type = $type . ($gridAdjustment !== false ? '-grid-adjuster' : '');
-        $view->columns = $columns;
-        $view->partialName = $partialName;
-        $view->equalHeight = $equalHeight;
-
+        $view->getParameters()->add([
+            'type'        => $type . ($gridAdjustment !== false ? '-grid-adjuster' : ''),
+            'columns'     => $columns,
+            'partialName' => $partialName,
+            'equalHeight' => $equalHeight
+        ]);
     }
 
     public function getName()

--- a/src/ToolboxBundle/Document/Areabrick/Download/Download.php
+++ b/src/ToolboxBundle/Document/Areabrick/Download/Download.php
@@ -84,7 +84,9 @@ class Download extends AbstractAreabrick
             }
         }
 
-        $view->downloads = $assets;
+        $view->getParameters()->add([
+            'downloads' => $assets
+        ]);
 
     }
 

--- a/src/ToolboxBundle/Document/Areabrick/Gallery/Gallery.php
+++ b/src/ToolboxBundle/Document/Areabrick/Gallery/Gallery.php
@@ -11,11 +11,19 @@ class Gallery extends AbstractAreabrick
     {
         parent::action($info);
 
-        $view = $info->getView();
-        $view->galleryId = 'gallery-' . uniqid();
-        $view->images = $this->getAssetArray(
-            $this->getDocumentTag($info->getDocument(), 'multihref', 'images')->getElements()
-        );
+        $infoParams = $info->getParams();
+        if (isset($infoParams['toolboxGalleryId'])) {
+            $id = $infoParams['toolboxGalleryId'];
+        } else {
+            $id = uniqid('gallery-');
+        }
+
+        $info->getView()->getParameters()->add([
+            'galleryId' => $id,
+            'images'    => $this->getAssetArray(
+                $this->getDocumentTag($info->getDocument(), 'multihref', 'images')->getElements()
+            )
+        ]);
     }
 
     public function getName()

--- a/src/ToolboxBundle/Document/Areabrick/GoogleMap/GoogleMap.php
+++ b/src/ToolboxBundle/Document/Areabrick/GoogleMap/GoogleMap.php
@@ -31,7 +31,7 @@ class GoogleMap extends AbstractAreabrick
     {
         parent::action($info);
 
-        $info->getView()->googleMapsHostUrl = $this->googleMapsHostUrl;
+        $info->getView()->getParameters()->add(['googleMapsHostUrl' => $this->googleMapsHostUrl]);
     }
 
     /**

--- a/src/ToolboxBundle/Document/Areabrick/Headline/Headline.php
+++ b/src/ToolboxBundle/Document/Areabrick/Headline/Headline.php
@@ -7,11 +7,15 @@ use Pimcore\Model\Document\Tag\Area\Info;
 
 class Headline extends AbstractAreabrick
 {
+    /**
+     * @param Info $info
+     *
+     * @return null|\Symfony\Component\HttpFoundation\Response|void
+     * @throws \Exception
+     */
     public function action(Info $info)
     {
         parent::action($info);
-
-        $view = $info->getView();
 
         $anchorName = null;
         $anchorNameElement = $this->getDocumentTag($info->getDocument(), 'input', 'anchor_name');
@@ -20,7 +24,7 @@ class Headline extends AbstractAreabrick
             $anchorName = \Pimcore\File::getValidFilename($anchorNameElement->getData());
         }
 
-        $view->anchorName = $anchorName;
+        $info->getView()->getParameters()->add(['anchorName' => $anchorName]);
 
     }
 

--- a/src/ToolboxBundle/Document/Areabrick/IFrame/IFrame.php
+++ b/src/ToolboxBundle/Document/Areabrick/IFrame/IFrame.php
@@ -11,6 +11,7 @@ class IFrame extends AbstractAreabrick
 {
     /**
      * @param Info $info
+     *
      * @return null|\Symfony\Component\HttpFoundation\Response|void
      * @throws \Exception
      */
@@ -32,15 +33,17 @@ class IFrame extends AbstractAreabrick
             }
         }
 
-        $view->isValid = $isValid;
-        $view->errorMessage = $errorMessage;
-        $view->initialHeight = is_numeric($initialHeight) ? (int)$initialHeight : null;
-        $view->iFrameUrl = $iFrameUrl;
-
+        $view->getParameters()->add([
+            'isValid'       => $isValid,
+            'errorMessage'  => $errorMessage,
+            'initialHeight' => is_numeric($initialHeight) ? (int)$initialHeight : null,
+            'iFrameUrl'     => $iFrameUrl
+        ]);
     }
 
     /**
      * @param $iFrameUrl
+     *
      * @return bool|string
      */
     private function checkIfUrlIsEmbeddable($iFrameUrl)

--- a/src/ToolboxBundle/Document/Areabrick/LinkList/LinkList.php
+++ b/src/ToolboxBundle/Document/Areabrick/LinkList/LinkList.php
@@ -9,6 +9,7 @@ class LinkList extends AbstractAreabrick
 {
     /**
      * @param Info $info
+     *
      * @return null|\Symfony\Component\HttpFoundation\Response|void
      * @throws \Exception
      */
@@ -19,7 +20,7 @@ class LinkList extends AbstractAreabrick
         $flags = $this->configManager->getConfig('flags');
         $useDynamicLinks = $flags['use_dynamic_links'];
 
-        $info->getView()->useDynamicLinks = $useDynamicLinks;
+        $info->getView()->getParameters()->add(['useDynamicLinks' => $useDynamicLinks]);
     }
 
     public function getViewTemplate()

--- a/src/ToolboxBundle/Document/Areabrick/ParallaxContainer/ParallaxContainer.php
+++ b/src/ToolboxBundle/Document/Areabrick/ParallaxContainer/ParallaxContainer.php
@@ -47,7 +47,6 @@ class ParallaxContainer extends AbstractAreabrick
                 ['elements' => $parallaxFront, 'backgroundImageMode' => $backgroundImageMode, 'document' => $info->getDocument()]
             ) : null;
 
-
         $info->getView()->getParameters()->add([
             'parallaxTemplate'     => $parallaxTemplate,
             'backgroundMode'       => $backgroundMode,
@@ -102,8 +101,7 @@ class ParallaxContainer extends AbstractAreabrick
             if ($info->getView()->get('editmode') === true) {
 
                 $configNode = $this->getConfigManager()->getAreaConfig('parallaxContainerSection');
-                $sectionConfig = $this->getBrickConfigBuilder()->buildElementConfig('parallaxContainerSection',
-                    'Parallax Container Section', $info, $configNode);
+                $sectionConfig = $this->getBrickConfigBuilder()->buildElementConfig('parallaxContainerSection', 'Parallax Container Section', $info, $configNode);
 
                 if ($containerWrapper === 'none' && strpos($areaBlock, 'toolbox-columns') !== false) {
                     $message = $translator->trans('You\'re using columns without a valid container wrapper.', [], 'admin');
@@ -117,7 +115,6 @@ class ParallaxContainer extends AbstractAreabrick
             }
 
             $sectionArgs = [
-
                 'backgroundTags'       => $backgroundTags,
                 'backgroundColorClass' => $backgroundColorClass,
                 'content'              => $areaBlock,

--- a/src/ToolboxBundle/Document/Areabrick/ParallaxContainer/ParallaxContainer.php
+++ b/src/ToolboxBundle/Document/Areabrick/ParallaxContainer/ParallaxContainer.php
@@ -9,14 +9,13 @@ class ParallaxContainer extends AbstractAreabrick
 {
     /**
      * @param Info $info
+     *
      * @return null|\Symfony\Component\HttpFoundation\Response|void
      * @throws \Exception
      */
     public function action(Info $info)
     {
         parent::action($info);
-
-        $view = $info->getView();
 
         $config = $this->getConfigManager()->getAreaParameterConfig('parallaxContainer');
 
@@ -48,13 +47,16 @@ class ParallaxContainer extends AbstractAreabrick
                 ['elements' => $parallaxFront, 'backgroundImageMode' => $backgroundImageMode, 'document' => $info->getDocument()]
             ) : null;
 
-        $view->parallaxTemplate = $parallaxTemplate;
-        $view->backgroundMode = $backgroundMode;
-        $view->backgroundTags = $backgroundTags;
-        $view->backgroundColorClass = $backgroundColorClass;
-        $view->behindElements = $behindElements;
-        $view->frontElements = $frontElements;
-        $view->sectionContent = $this->_buildSectionContent($info, $templating, $translator);
+
+        $info->getView()->getParameters()->add([
+            'parallaxTemplate'     => $parallaxTemplate,
+            'backgroundMode'       => $backgroundMode,
+            'backgroundTags'       => $backgroundTags,
+            'backgroundColorClass' => $backgroundColorClass,
+            'behindElements'       => $behindElements,
+            'frontElements'        => $frontElements,
+            'sectionContent'       => $this->_buildSectionContent($info, $templating, $translator)
+        ]);
 
     }
 
@@ -62,6 +64,7 @@ class ParallaxContainer extends AbstractAreabrick
      * @param Info $info
      * @param      $templating
      * @param      $translator
+     *
      * @return string
      * @throws \Exception
      */
@@ -99,13 +102,15 @@ class ParallaxContainer extends AbstractAreabrick
             if ($info->getView()->get('editmode') === true) {
 
                 $configNode = $this->getConfigManager()->getAreaConfig('parallaxContainerSection');
-                $sectionConfig = $this->getBrickConfigBuilder()->buildElementConfig('parallaxContainerSection', 'Parallax Container Section', $info, $configNode);
+                $sectionConfig = $this->getBrickConfigBuilder()->buildElementConfig('parallaxContainerSection',
+                    'Parallax Container Section', $info, $configNode);
 
                 if ($containerWrapper === 'none' && strpos($areaBlock, 'toolbox-columns') !== false) {
                     $message = $translator->trans('You\'re using columns without a valid container wrapper.', [], 'admin');
-                    $messageWrap = $templating->render('@Toolbox/Helper/field-alert.' . $this->getTemplateSuffix(), ['type'     => 'danger',
-                                                                                                                     'message'  => $message,
-                                                                                                                     'document' => $info->getDocument()
+                    $messageWrap = $templating->render('@Toolbox/Helper/field-alert.' . $this->getTemplateSuffix(), [
+                        'type'     => 'danger',
+                        'message'  => $message,
+                        'document' => $info->getDocument()
                     ]);
                     $areaBlock = $messageWrap . $areaBlock;
                 }
@@ -138,6 +143,7 @@ class ParallaxContainer extends AbstractAreabrick
      * @param        $backgroundColor
      * @param array  $config
      * @param string $type
+     *
      * @return string
      * @throws \Exception
      */
@@ -192,6 +198,7 @@ class ParallaxContainer extends AbstractAreabrick
      * @param        $backgroundColor
      * @param array  $config
      * @param string $type
+     *
      * @return string
      */
     private function getBackgroundColorClass($backgroundColor, $config = [], $type = 'parallax')

--- a/src/ToolboxBundle/Document/Areabrick/SlideColumns/SlideColumns.php
+++ b/src/ToolboxBundle/Document/Areabrick/SlideColumns/SlideColumns.php
@@ -23,14 +23,13 @@ class SlideColumns extends AbstractAreabrick
 
     /**
      * @param Info $info
+     *
      * @return null|\Symfony\Component\HttpFoundation\Response|void
      * @throws \Exception
      */
     public function action(Info $info)
     {
         parent::action($info);
-
-        $view = $info->getView();
 
         $equalHeight = $this->getDocumentTag($info->getDocument(), 'checkbox', 'equal_height')->isChecked() && !$info->getView()->get('editmode');
         $id = $info->getView()->get('brick')->getId() . '-' . $info->getView()->get('brick')->getIndex();
@@ -45,12 +44,15 @@ class SlideColumns extends AbstractAreabrick
         $slidesPerViewClass = $calculator->calculateSlideColumnClasses($slidesPerView, $slideColumnConfig);
         $breakpoints = $this->calculateSlideColumnBreakpoints($slidesPerView);
 
-        $view->id = $id;
-        $view->slideElements = $slideElements;
-        $view->slidesPerView = $slidesPerView;
-        $view->slidesPerViewClasses = $slidesPerViewClass;
-        $view->breakpoints = $breakpoints;
-        $view->equalHeight = $equalHeight;
+        $info->getView()->getParameters()->add([
+            'id'                   => $id,
+            'slideElements'        => $slideElements,
+            'slidesPerView'        => $slidesPerView,
+            'slidesPerViewClasses' => $slidesPerViewClass,
+            'breakpoints'          => $breakpoints,
+            'equalHeight'          => $equalHeight
+        ]);
+
     }
 
     public function getName()
@@ -65,6 +67,7 @@ class SlideColumns extends AbstractAreabrick
 
     /**
      * @param $columnType
+     *
      * @return array
      * @throws \Exception
      */

--- a/src/ToolboxBundle/Document/Areabrick/Teaser/Teaser.php
+++ b/src/ToolboxBundle/Document/Areabrick/Teaser/Teaser.php
@@ -9,6 +9,7 @@ class Teaser extends AbstractAreabrick
 {
     /**
      * @param Info $info
+     *
      * @return null|\Symfony\Component\HttpFoundation\Response|void
      * @throws \Exception
      */
@@ -19,7 +20,7 @@ class Teaser extends AbstractAreabrick
         $flags = $this->configManager->getConfig('flags');
         $useDynamicLinks = $flags['use_dynamic_links'];
 
-        $info->getView()->useDynamicLinks = $useDynamicLinks;
+        $info->getView()->getParameters()->add(['useDynamicLinks' => $useDynamicLinks]);
     }
 
     public function getName()

--- a/src/ToolboxBundle/Document/Areabrick/Video/Video.php
+++ b/src/ToolboxBundle/Document/Areabrick/Video/Video.php
@@ -10,6 +10,7 @@ class Video extends AbstractAreabrick
 {
     /**
      * @param Info $info
+     *
      * @return null|\Symfony\Component\HttpFoundation\Response|void
      * @throws \Exception
      */
@@ -35,11 +36,13 @@ class Video extends AbstractAreabrick
             $posterPath = $poster->getThumbnail($imageThumbnail);
         }
 
-        $view->autoPlay = $autoPlay;
-        $view->posterPath = $posterPath;
-        $view->videoType = $videoType;
-        $view->playInLightbox = $playInLightBox;
-        $view->videoId = $videoId;
+        $view->getParameters()->add([
+            'autoPlay'       => $autoPlay,
+            'posterPath'     => $posterPath,
+            'videoType'      => $videoType,
+            'playInLightbox' => $playInLightBox,
+            'videoId'        => $videoId
+        ]);
     }
 
     public function getName()

--- a/src/ToolboxBundle/Model/Document/Tag/GoogleMap.php
+++ b/src/ToolboxBundle/Model/Document/Tag/GoogleMap.php
@@ -9,6 +9,16 @@ use ToolboxBundle\Manager\ConfigManagerInterface;
 class GoogleMap extends Document\Tag
 {
     /**
+     * @var bool
+     */
+    private $disableGoogleLookUp = false;
+
+    /**
+     * @var int
+     */
+    private $mapId;
+
+    /**
      * Contains the data
      *
      * @var array
@@ -85,11 +95,11 @@ class GoogleMap extends Document\Tag
             array_keys($dataAttr)
         ));
 
-        if (!$this->id) {
-            $this->id = uniqid('map-');
+        if (empty($this->getId())) {
+            $this->mapId = uniqid('map-');
         }
 
-        $html = '<div class="embed-responsive-item toolbox-googlemap" id="' . $this->id . '" ' . $dataAttrString . '></div>';
+        $html = '<div class="embed-responsive-item toolbox-googlemap" id="' . $this->mapId . '" ' . $dataAttrString . '></div>';
 
         return $html;
     }
@@ -128,7 +138,9 @@ class GoogleMap extends Document\Tag
 
     /**
      * @see Document\Tag\TagInterface::setDataFromEditmode
+     *
      * @param mixed $data
+     *
      * @return $this
      * @throws \Exception
      */
@@ -149,15 +161,42 @@ class GoogleMap extends Document\Tag
     }
 
     /**
-     * @return mixed
+     * @return bool
+     */
+    public function googleLookUpIsDisabled()
+    {
+        return $this->disableGoogleLookUp;
+    }
+
+    public function disableGoogleLookup()
+    {
+        $this->disableGoogleLookUp = true;
+    }
+
+    public function enableGoogleLookup()
+    {
+        $this->disableGoogleLookUp = false;
+    }
+
+    /**
+     * @param $mapId
+     */
+    public function setId($mapId)
+    {
+        $this->mapId = $mapId;
+    }
+
+    /**
+     * @return null|int
      */
     public function getId()
     {
-        return $this->id;
+        return $this->mapId;
     }
 
     /**
      * @param $location
+     *
      * @return mixed
      * @throws \Exception
      */
@@ -173,6 +212,10 @@ class GoogleMap extends Document\Tag
         $key = '';
         if (!empty($configNode) && isset($configNode['map_api_key']) && !empty($configNode['map_api_key'])) {
             $key = '&key=' . $configNode['map_api_key'];
+        }
+
+        if ($this->googleLookUpIsDisabled()) {
+            return $location;
         }
 
         $url = 'https://maps.google.com/maps/api/geocode/json?address=' . $address . $key;

--- a/src/ToolboxBundle/Resources/config/pimcore/areas/columns.yml
+++ b/src/ToolboxBundle/Resources/config/pimcore/areas/columns.yml
@@ -26,3 +26,7 @@ toolbox:
                     title: 'Equal heights?'
                     config:
                         reload: false
+                additional_classes:
+                    type: additionalClasses
+                    config:
+                        store: ~

--- a/src/ToolboxBundle/Resources/config/pimcore/areas/container.yml
+++ b/src/ToolboxBundle/Resources/config/pimcore/areas/container.yml
@@ -12,3 +12,7 @@ toolbox:
                     title: 'Fluid Container (Full Width)'
                     config:
                         reload: true
+                additional_classes:
+                    type: additionalClasses
+                    config:
+                        store: ~

--- a/src/ToolboxBundle/Resources/config/pimcore/areas/googleMap.yml
+++ b/src/ToolboxBundle/Resources/config/pimcore/areas/googleMap.yml
@@ -38,6 +38,10 @@ toolbox:
                     title: 'Open Info Window by Default'
                     config:
                         reload: false
+                additional_classes:
+                    type: additionalClasses
+                    config:
+                        store: ~
             config_parameter:
                 map_options:
                     streetViewControl: true

--- a/src/ToolboxBundle/Resources/config/pimcore/areas/parallaxContainer.yml
+++ b/src/ToolboxBundle/Resources/config/pimcore/areas/parallaxContainer.yml
@@ -72,6 +72,10 @@ toolbox:
                             third-window-width: 'Third Window Width'
                             quarter-window-width: 'Quarter Window Width'
                         reload: true
+                additional_classes:
+                    type: additionalClasses
+                    config:
+                        store: ~
             config_parameter:
                 window_size: large
                 background_mode: wrap

--- a/src/ToolboxBundle/Resources/config/pimcore/areas/slideColumns.yml
+++ b/src/ToolboxBundle/Resources/config/pimcore/areas/slideColumns.yml
@@ -23,6 +23,10 @@ toolbox:
                     title: 'Equal heights?'
                     config:
                         reload: false
+                additional_classes:
+                    type: additionalClasses
+                    config:
+                        store: ~
             config_parameter:
                 column_classes:
                     '2': 'col-12 col-sm-6'

--- a/src/ToolboxBundle/Resources/config/pimcore/areas/spacer.yml
+++ b/src/ToolboxBundle/Resources/config/pimcore/areas/spacer.yml
@@ -16,7 +16,6 @@ toolbox:
                             spacer-none: 'No Space'
                             spacer-50: '50 Pixel'
                         default: spacer-none
-
                 additional_classes:
                     type: additionalClasses
                     config:

--- a/src/ToolboxBundle/Resources/views/Toolbox/Bootstrap4/Image/view.html.twig
+++ b/src/ToolboxBundle/Resources/views/Toolbox/Bootstrap4/Image/view.html.twig
@@ -12,8 +12,6 @@
     {% endif %}
 
     {% if pimcore_checkbox('show_caption').isChecked() == true %}
-        <span class="caption">
-            {{ pimcore_image('ci').text }}
-        </span>
+        <span class="caption">{{ pimcore_image('ci').text }}</span>
     {% endif %}
 </div>

--- a/src/ToolboxBundle/Resources/views/Toolbox/Bootstrap4/ParallaxContainer/Partial/background-prepend.html.twig
+++ b/src/ToolboxBundle/Resources/views/Toolbox/Bootstrap4/ParallaxContainer/Partial/background-prepend.html.twig
@@ -1,4 +1,4 @@
-<div class="parallax-background {{ backgroundColorClass }}" {{ backgroundTags }}></div>
+<div class="parallax-background {{ backgroundColorClass }}" {{ backgroundTags|raw }}></div>
 <div class="parallax-content-wrapper">
     {% include toolbox_area_path(areaId, 'Partial/parallax-content') with {
     'behindElements' : behindElements,

--- a/src/ToolboxBundle/Resources/views/Toolbox/Bootstrap4/ParallaxContainer/Partial/background-wrap.html.twig
+++ b/src/ToolboxBundle/Resources/views/Toolbox/Bootstrap4/ParallaxContainer/Partial/background-wrap.html.twig
@@ -1,4 +1,4 @@
-<div class="parallax-background {{ backgroundColorClass }}" {{ backgroundTags }}>
+<div class="parallax-background {{ backgroundColorClass }}" {{ backgroundTags|raw }}>
     {% include toolbox_area_path(areaId, 'Partial/parallax-content') with {
     'behindElements' : behindElements,
     'frontElements' : frontElements,

--- a/src/ToolboxBundle/Resources/views/Toolbox/Bootstrap4/ParallaxContainer/Partial/behind-front-elements.html.twig
+++ b/src/ToolboxBundle/Resources/views/Toolbox/Bootstrap4/ParallaxContainer/Partial/behind-front-elements.html.twig
@@ -1,6 +1,6 @@
 {% for element in elements.elements %}
 
-    {% set imageUrl = element.obj is instanceof('\Pimcore\Model\Asset')
+    {% set imageUrl = element.obj is not null
         ? element.obj.thumbnail(toolbox_get_image_thumbnail('parallax_container_element'))
         : '' %}
 
@@ -14,7 +14,7 @@
     {% set height = element['obj'].thumbnail(toolbox_get_image_thumbnail('parallax_container_element')).height %}
 
     <div class="element position-{{ element.parallaxPosition }} size-{{ element.parallaxSize }}"
-        {{ parallaxImageTag }}
+        {{ parallaxImageTag|raw }}
         data-width="{{ width is empty ? orgWidth : width }}" data-height="{{ height is empty ? orgHeight : height }}"
         data-element-position="{{ element.parallaxPosition }}"
         data-element-size="{{ element.parallaxSize }}">

--- a/tests/bundle_tests/unit_areas.suite.dist.yml
+++ b/tests/bundle_tests/unit_areas.suite.dist.yml
@@ -1,0 +1,7 @@
+class_name: UnitTester
+modules:
+    enabled:
+        - \DachcomBundle\Test\Helper\PimcoreBundle:
+            connect_db: true
+            configuration_file: config_default.yml
+        - \DachcomBundle\Test\Helper\Unit

--- a/tests/bundle_tests/unit_areas/AbstractAreaTest.php
+++ b/tests/bundle_tests/unit_areas/AbstractAreaTest.php
@@ -7,6 +7,7 @@ use Pimcore\Model\Document\Tag\Area;
 use Pimcore\Templating\Model\ViewModel;
 use Pimcore\Tests\Util\TestHelper;
 use Symfony\Component\HttpFoundation\Request;
+use ToolboxBundle\Builder\BrickConfigBuilder;
 use ToolboxBundle\Manager\ConfigManager;
 use ToolboxBundle\Manager\ConfigManagerInterface;
 
@@ -21,7 +22,7 @@ abstract class AbstractAreaTest extends DachcomBundleTestCase
         $configManager = $this->getContainer()->get(ConfigManager::class);
         $configManager->setAreaNameSpace(ConfigManagerInterface::AREABRICK_NAMESPACE_INTERNAL);
 
-        return$configManager;
+        return $configManager;
     }
 
     /**
@@ -37,6 +38,28 @@ abstract class AbstractAreaTest extends DachcomBundleTestCase
         $info->getTag()->getView()->get('document')->setElements($documentElements);
 
         return $this->getAreaOutput($info);
+    }
+
+    /**
+     * @param $id
+     *
+     * @return mixed
+     * @throws \Exception
+     */
+    public function generateBackendArea($id)
+    {
+        $info = $this->generateAreaInfo($id);
+
+        $info->getView()->getParameters()->add(['editmode' => true]);
+
+        $builder = $this->getContainer()->get(BrickConfigBuilder::class);
+        $configManager = $this->getContainer()->get(ConfigManager::class);
+        $configManager->setAreaNameSpace(ConfigManagerInterface::AREABRICK_NAMESPACE_INTERNAL);
+
+        $configNode = $configManager->getAreaConfig($info->getId());
+        $themeOptions = $configManager->getConfig('theme');
+
+        return $builder->buildElementConfigArguments($info->getId(), $info->getTag()->getName(), $info, $configNode, $themeOptions);
     }
 
     /**
@@ -56,10 +79,12 @@ abstract class AbstractAreaTest extends DachcomBundleTestCase
 
         $area = new Area();
         $area->setView($view);
+        $area->setName($id);
 
         $info = new Area\Info();
         $info->setId($id);
         $info->setTag($area);
+        $info->setView($view);
         $info->setIndex(1);
         $info->setParams($infoParams);
         return $info;

--- a/tests/bundle_tests/unit_areas/AbstractAreaTest.php
+++ b/tests/bundle_tests/unit_areas/AbstractAreaTest.php
@@ -7,9 +7,23 @@ use Pimcore\Model\Document\Tag\Area;
 use Pimcore\Templating\Model\ViewModel;
 use Pimcore\Tests\Util\TestHelper;
 use Symfony\Component\HttpFoundation\Request;
+use ToolboxBundle\Manager\ConfigManager;
+use ToolboxBundle\Manager\ConfigManagerInterface;
 
 abstract class AbstractAreaTest extends DachcomBundleTestCase
 {
+    /**
+     * @return object|ConfigManager
+     * @throws \Codeception\Exception\ModuleException
+     */
+    public function getToolboxConfig()
+    {
+        $configManager = $this->getContainer()->get(ConfigManager::class);
+        $configManager->setAreaNameSpace(ConfigManagerInterface::AREABRICK_NAMESPACE_INTERNAL);
+
+        return$configManager;
+    }
+
     /**
      * @param       $id
      * @param       $documentElements
@@ -23,7 +37,6 @@ abstract class AbstractAreaTest extends DachcomBundleTestCase
         $info->getTag()->getView()->get('document')->setElements($documentElements);
 
         return $this->getAreaOutput($info);
-
     }
 
     /**

--- a/tests/bundle_tests/unit_areas/AbstractAreaTest.php
+++ b/tests/bundle_tests/unit_areas/AbstractAreaTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace DachcomBundle\Test\Unit;
+
+use DachcomBundle\Test\Test\DachcomBundleTestCase;
+use Pimcore\Model\Document\Tag\Area;
+use Pimcore\Templating\Model\ViewModel;
+use Pimcore\Tests\Util\TestHelper;
+use Symfony\Component\HttpFoundation\Request;
+
+abstract class AbstractAreaTest extends DachcomBundleTestCase
+{
+    /**
+     * @param       $id
+     * @param       $documentElements
+     * @param array $infoParams
+     *
+     * @return string
+     */
+    public function generateRenderedArea($id, $documentElements, $infoParams = [])
+    {
+        $info = $this->generateAreaInfo($id, $infoParams);
+        $info->getTag()->getView()->get('document')->setElements($documentElements);
+
+        return $this->getAreaOutput($info);
+
+    }
+
+    /**
+     * @param       $id
+     * @param array $infoParams
+     *
+     * @return Area\Info
+     */
+    public function generateAreaInfo($id, $infoParams = [])
+    {
+        $document = TestHelper::createEmptyDocumentPage('', true);
+
+        $view = new ViewModel([
+            'editmode' => false,
+            'document' => $document
+        ]);
+
+        $area = new Area();
+        $area->setView($view);
+
+        $info = new Area\Info();
+        $info->setId($id);
+        $info->setTag($area);
+        $info->setIndex(1);
+        $info->setParams($infoParams);
+        return $info;
+    }
+
+    /**
+     * @param Area\Info $info
+     *
+     * @return string
+     */
+    public function getAreaOutput(Area\Info $info)
+    {
+        $tagHandler = \Pimcore::getContainer()->get('pimcore.document.tag.handler');
+
+        ob_start();
+        $tagHandler->renderAreaFrontend($info);
+        $output = ob_get_contents();
+        ob_end_clean();
+
+        return $output;
+
+    }
+
+    /**
+     * @param $output
+     *
+     * @return string
+     */
+    public function filter($output)
+    {
+        $output = preg_replace('/\r|\n/', '', $output);
+        return trim(preg_replace('/(\>)\s*(\<)/m', '$1$2', $output));
+    }
+
+    /**
+     * @throws \Codeception\Exception\ModuleException
+     */
+    public function setupRequest()
+    {
+        $request = Request::create('/');
+        $requestStack = $this->getContainer()->get('request_stack');
+        $requestStack->push($request);
+    }
+}

--- a/tests/bundle_tests/unit_areas/AccordionTest.php
+++ b/tests/bundle_tests/unit_areas/AccordionTest.php
@@ -6,12 +6,29 @@ use Pimcore\Model\Document\Tag\Select;
 
 class AccordionTest extends AbstractAreaTest
 {
+    const TYPE = 'accordion';
+
+    public function testAccordionBackendConfig()
+    {
+        $this->setupRequest();
+
+        $areaConfig = $this->generateBackendArea(self::TYPE);
+        $configElements = $areaConfig['config_elements'];
+
+        $this->assertCount(2, $configElements);
+        $this->assertEquals('select', $configElements[0]['additional_config']['type']);
+        $this->assertEquals('type', $configElements[0]['additional_config']['name']);
+
+        $this->assertEquals('select', $configElements[1]['additional_config']['type']);
+        $this->assertEquals('component', $configElements[1]['additional_config']['name']);
+    }
+
     public function testAccordion()
     {
         $this->setupRequest();
 
         $component = new Select();
-        $component->setDataFromResource('accordion');
+        $component->setDataFromResource(self::TYPE);
 
         $elements = [
             'component' => $component
@@ -19,7 +36,7 @@ class AccordionTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareDefault()),
-            $this->filter($this->generateRenderedArea('accordion', $elements, ['toolboxAccordionId' => 'test']))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements, ['toolboxAccordionId' => 'test']))
         );
     }
 
@@ -39,8 +56,8 @@ class AccordionTest extends AbstractAreaTest
         ];
 
         $this->assertEquals(
-            $this->filter($this->getCompareWithAdditionalClasses()),
-            $this->filter($this->generateRenderedArea('accordion', $elements, ['toolboxAccordionId' => 'test']))
+            $this->filter($this->getCompareWithAdditionalClass()),
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements, ['toolboxAccordionId' => 'test']))
         );
     }
 
@@ -57,7 +74,7 @@ class AccordionTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareTabs()),
-            $this->filter($this->generateRenderedArea('accordion', $elements, ['toolboxAccordionId' => 'test']))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements, ['toolboxAccordionId' => 'test']))
         );
     }
 
@@ -90,7 +107,7 @@ class AccordionTest extends AbstractAreaTest
             </div>';
     }
 
-    private function getCompareWithAdditionalClasses()
+    private function getCompareWithAdditionalClass()
     {
         return '
             <div class="toolbox-element toolbox-accordion component-accordion additional-class">

--- a/tests/bundle_tests/unit_areas/AccordionTest.php
+++ b/tests/bundle_tests/unit_areas/AccordionTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace DachcomBundle\Test\Unit;
+
+use Pimcore\Model\Document\Tag\Select;
+
+class AccordionTest extends AbstractAreaTest
+{
+    public function testAccordion()
+    {
+        $this->setupRequest();
+
+        $component = new Select();
+        $component->setDataFromResource('accordion');
+
+        $elements = [
+            'component' => $component
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareDefault()),
+            $this->filter($this->generateRenderedArea('accordion', $elements, ['toolboxAccordionId' => 'test']))
+        );
+    }
+
+    public function testAccordionWithAdditionalClass()
+    {
+        $this->setupRequest();
+
+        $component = new Select();
+        $component->setDataFromResource('accordion');
+
+        $combo = new Select();
+        $combo->setDataFromResource('additional-class');
+
+        $elements = [
+            'component' => $component,
+            'add_classes' => $combo,
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithAdditionalClasses()),
+            $this->filter($this->generateRenderedArea('accordion', $elements, ['toolboxAccordionId' => 'test']))
+        );
+    }
+
+    public function testAccordionTabs()
+    {
+        $this->setupRequest();
+
+        $component = new Select();
+        $component->setDataFromResource('tab');
+
+        $elements = [
+            'component' => $component
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareTabs()),
+            $this->filter($this->generateRenderedArea('accordion', $elements, ['toolboxAccordionId' => 'test']))
+        );
+    }
+
+    private function getCompareDefault()
+    {
+        return '
+            <div class="toolbox-element toolbox-accordion component-accordion ">
+                <div class="accordion" id="test" role="tablist" aria-multiselectable="true">
+                    <div class="card "> 
+                        <div class="card-header" role="tab" id="test-1">
+                            <span class="mb-0">
+                                <a href="#collapse-test-1" data-target="#collapse-test-1" class="accordion-toggle collapsed" data-toggle="collapse"></a>
+                            </span>
+                        </div>
+                        <div id="collapse-test-1" role="tabpanel" aria-labelledby="test-1" class="collapse " data-parent="#test">
+                            <div class="card-body"></div>
+                        </div>
+                    </div>
+                    <div class="card ">
+                        <div class="card-header" role="tab" id="test-2">
+                            <span class="mb-0">
+                                <a href="#collapse-test-2" data-target="#collapse-test-2" class="accordion-toggle collapsed" data-toggle="collapse"></a>
+                            </span>
+                        </div>
+                        <div id="collapse-test-2" role="tabpanel" aria-labelledby="test-2" class="collapse " data-parent="#test">
+                            <div class="card-body"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>';
+    }
+
+    private function getCompareWithAdditionalClasses()
+    {
+        return '
+            <div class="toolbox-element toolbox-accordion component-accordion additional-class">
+                <div class="accordion" id="test" role="tablist" aria-multiselectable="true">
+                    <div class="card "> 
+                        <div class="card-header" role="tab" id="test-1">
+                            <span class="mb-0">
+                                <a href="#collapse-test-1" data-target="#collapse-test-1" class="accordion-toggle collapsed" data-toggle="collapse"></a>
+                            </span>
+                        </div>
+                        <div id="collapse-test-1" role="tabpanel" aria-labelledby="test-1" class="collapse " data-parent="#test">
+                            <div class="card-body"></div>
+                        </div>
+                    </div>
+                    <div class="card ">
+                        <div class="card-header" role="tab" id="test-2">
+                            <span class="mb-0">
+                                <a href="#collapse-test-2" data-target="#collapse-test-2" class="accordion-toggle collapsed" data-toggle="collapse"></a>
+                            </span>
+                        </div>
+                        <div id="collapse-test-2" role="tabpanel" aria-labelledby="test-2" class="collapse " data-parent="#test">
+                            <div class="card-body"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>';
+    }
+
+    private function getCompareTabs()
+    {
+        return '
+            <div class="toolbox-element toolbox-accordion component-tab ">
+                <div class="tabs" id="test">
+                    <ul class="nav nav-tabs" role="tablist">
+                        <li class=" nav-item">
+                            <a href="#panel-test-1" id="tab-test-1" class="nav-link active" aria-controls="panel-test-1" role="tab" data-toggle="tab" aria-expanded="true"></a>
+                        </li>
+                        <li class=" nav-item">
+                            <a href="#panel-test-2" id="tab-test-2" class="nav-link " aria-controls="panel-test-2" role="tab" data-toggle="tab" aria-expanded="false"></a>
+                        </li>
+                    </ul>
+                    <div class="tab-content">
+                        <div role="tabpanel" class="tab-pane fade show active" id="panel-test-1" aria-labelledby="tab-test-1"></div>
+                        <div role="tabpanel" class="tab-pane fade " id="panel-test-2" aria-labelledby="tab-test-2"></div>
+                    </div>
+                </div>
+            </div>';
+    }
+}

--- a/tests/bundle_tests/unit_areas/AnchorTest.php
+++ b/tests/bundle_tests/unit_areas/AnchorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DachcomBundle\Test\Unit;
+
+use Pimcore\Model\Document\Tag\Input;
+
+class AnchorTest extends AbstractAreaTest
+{
+    public function testAccordion()
+    {
+        $this->setupRequest();
+
+        $name = new Input();
+        $name->setDataFromResource('AnchorId');
+
+        $title = new Input();
+        $title->setDataFromResource('Anchor Title');
+
+        $elements = [
+            'anchor_name'  => $name,
+            'anchor_title' => $title
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompare()),
+            $this->filter($this->generateRenderedArea('anchor', $elements))
+        );
+    }
+
+    private function getCompare()
+    {
+        return '<a class="toolbox-element toolbox-anchor" id="AnchorId" data-anchortitle="Anchor Title"></a>';
+    }
+}

--- a/tests/bundle_tests/unit_areas/AnchorTest.php
+++ b/tests/bundle_tests/unit_areas/AnchorTest.php
@@ -6,6 +6,23 @@ use Pimcore\Model\Document\Tag\Input;
 
 class AnchorTest extends AbstractAreaTest
 {
+    const TYPE = 'anchor';
+
+    public function testAnchorBackendConfig()
+    {
+        $this->setupRequest();
+
+        $areaConfig = $this->generateBackendArea(self::TYPE);
+        $configElements = $areaConfig['config_elements'];
+
+        $this->assertCount(2, $configElements);
+        $this->assertEquals('input', $configElements[0]['additional_config']['type']);
+        $this->assertEquals('anchor_name', $configElements[0]['additional_config']['name']);
+
+        $this->assertEquals('input', $configElements[1]['additional_config']['type']);
+        $this->assertEquals('anchor_title', $configElements[1]['additional_config']['name']);
+    }
+
     public function testAccordion()
     {
         $this->setupRequest();
@@ -23,7 +40,7 @@ class AnchorTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompare()),
-            $this->filter($this->generateRenderedArea('anchor', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 

--- a/tests/bundle_tests/unit_areas/ColumnsTest.php
+++ b/tests/bundle_tests/unit_areas/ColumnsTest.php
@@ -8,6 +8,26 @@ use ToolboxBundle\Model\Document\Tag\ColumnAdjuster;
 
 class ColumnsTest extends AbstractAreaTest
 {
+    const TYPE = 'columns';
+
+    public function testColumnsBackendConfig()
+    {
+        $this->setupRequest();
+
+        $areaConfig = $this->generateBackendArea(self::TYPE);
+        $configElements = $areaConfig['config_elements'];
+
+        $this->assertCount(3, $configElements);
+        $this->assertEquals('select', $configElements[0]['additional_config']['type']);
+        $this->assertEquals('type', $configElements[0]['additional_config']['name']);
+
+        $this->assertEquals('columnadjuster', $configElements[1]['additional_config']['type']);
+        $this->assertEquals('columnadjuster', $configElements[1]['additional_config']['name']);
+
+        $this->assertEquals('checkbox', $configElements[2]['additional_config']['type']);
+        $this->assertEquals('equal_height', $configElements[2]['additional_config']['name']);
+    }
+
     public function testDefaultColumns()
     {
         $this->setupRequest();
@@ -21,7 +41,7 @@ class ColumnsTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompare()),
-            $this->filter($this->generateRenderedArea('columns', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -42,7 +62,7 @@ class ColumnsTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithEqualHeights()),
-            $this->filter($this->generateRenderedArea('columns', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -62,8 +82,8 @@ class ColumnsTest extends AbstractAreaTest
         ];
 
         $this->assertEquals(
-            $this->filter($this->getCompareWithAdditionalClasses()),
-            $this->filter($this->generateRenderedArea('columns', $elements))
+            $this->filter($this->getCompareWithAdditionalClass()),
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -90,7 +110,7 @@ class ColumnsTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithColumnsAdjuster()),
-            $this->filter($this->generateRenderedArea('columns', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -122,7 +142,7 @@ class ColumnsTest extends AbstractAreaTest
                 </div>';
     }
 
-    private function getCompareWithAdditionalClasses()
+    private function getCompareWithAdditionalClass()
     {
         return '<div class="toolbox-element toolbox-columns type-column_4_8 additional-class ">
                     <div class="row">

--- a/tests/bundle_tests/unit_areas/ColumnsTest.php
+++ b/tests/bundle_tests/unit_areas/ColumnsTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace DachcomBundle\Test\Unit;
+
+use Pimcore\Model\Document\Tag\Checkbox;
+use Pimcore\Model\Document\Tag\Select;
+use ToolboxBundle\Model\Document\Tag\ColumnAdjuster;
+
+class ColumnsTest extends AbstractAreaTest
+{
+    public function testDefaultColumns()
+    {
+        $this->setupRequest();
+
+        $type = new Select();
+        $type->setDataFromResource('column_4_8');
+
+        $elements = [
+            'type' => $type
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompare()),
+            $this->filter($this->generateRenderedArea('columns', $elements))
+        );
+    }
+
+    public function testColumnsWithEqualHeight()
+    {
+        $this->setupRequest();
+
+        $type = new Select();
+        $type->setDataFromResource('column_4_8');
+
+        $checkbox = new Checkbox();
+        $checkbox->setDataFromResource(1);
+
+        $elements = [
+            'type'         => $type,
+            'equal_height' => $checkbox
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithEqualHeights()),
+            $this->filter($this->generateRenderedArea('columns', $elements))
+        );
+    }
+
+    public function testColumnsWithAdditionalClass()
+    {
+        $this->setupRequest();
+
+        $type = new Select();
+        $type->setDataFromResource('column_4_8');
+
+        $combo = new Select();
+        $combo->setDataFromResource('additional-class');
+
+        $elements = [
+            'type'        => $type,
+            'add_classes' => $combo
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithAdditionalClasses()),
+            $this->filter($this->generateRenderedArea('columns', $elements))
+        );
+    }
+
+    public function testColumnsWithColumnsAdjuster()
+    {
+        $this->setupRequest();
+
+        $type = new Select();
+        $type->setDataFromResource('column_4_8');
+
+        $combo = new ColumnAdjuster();
+        $combo->setDataFromResource(serialize([
+            'breakpoints' => [
+                'xs' => '4_4',
+                'sm' => '4_8',
+                'lg' => '1_11'
+            ]
+        ]));
+
+        $elements = [
+            'type'           => $type,
+            'columnadjuster' => $combo
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithColumnsAdjuster()),
+            $this->filter($this->generateRenderedArea('columns', $elements))
+        );
+    }
+
+    private function getCompare()
+    {
+        return '<div class="toolbox-element toolbox-columns type-column_4_8  ">
+                    <div class="row">
+                        <div class="col-12 col-sm-4 ">
+                            <div class="toolbox-column"></div>
+                        </div>
+                        <div class="col-12 col-sm-8 ">
+                            <div class="toolbox-column"></div>
+                        </div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareWithEqualHeights()
+    {
+        return '<div class="toolbox-element toolbox-columns type-column_4_8  equal-height">
+                    <div class="row">
+                        <div class="col-12 col-sm-4 ">
+                            <div class="toolbox-column equal-height-item"></div>
+                        </div>
+                        <div class="col-12 col-sm-8 ">
+                            <div class="toolbox-column equal-height-item"></div>
+                        </div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareWithAdditionalClasses()
+    {
+        return '<div class="toolbox-element toolbox-columns type-column_4_8 additional-class ">
+                    <div class="row">
+                        <div class="col-12 col-sm-4 ">
+                            <div class="toolbox-column"></div>
+                        </div>
+                        <div class="col-12 col-sm-8 ">
+                            <div class="toolbox-column"></div>
+                        </div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareWithColumnsAdjuster()
+    {
+        return '<div class="toolbox-element toolbox-columns type-column_4_8-grid-adjuster  ">
+                    <div class="row">
+                        <div class="col-4 col-sm-4 col-lg-1 ">
+                            <div class="toolbox-column"></div>
+                        </div>
+                        <div class="col-4 col-sm-8 col-lg-11 ">
+                            <div class="toolbox-column"></div>
+                        </div>
+                    </div>
+                </div>';
+    }
+}

--- a/tests/bundle_tests/unit_areas/ContainerTest.php
+++ b/tests/bundle_tests/unit_areas/ContainerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace DachcomBundle\Test\Unit;
+
+use Pimcore\Model\Document\Tag\Checkbox;
+use Pimcore\Model\Document\Tag\Image;
+use Pimcore\Model\Document\Tag\Link;
+use Pimcore\Model\Document\Tag\Select;
+use Pimcore\Tests\Util\TestHelper;
+
+class ContainerTest extends AbstractAreaTest
+{
+    public function testImage()
+    {
+        $this->setupRequest();
+
+        $elements = [
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareDefault()),
+            $this->filter($this->generateRenderedArea('container', $elements))
+        );
+    }
+
+    public function testContainerWithFullWidth()
+    {
+        $this->setupRequest();
+
+        $checkbox = new Checkbox();
+        $checkbox->setDataFromResource(1);
+
+        $elements = [
+            'full_width_container' => $checkbox
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithFullWidth()),
+            $this->filter($this->generateRenderedArea('container', $elements))
+        );
+
+    }
+
+    public function testContainerWithAdditionalClass()
+    {
+        $this->setupRequest();
+
+        $combo = new Select();
+        $combo->setDataFromResource('additional-class');
+
+        $elements = [
+            'add_classes' => $combo,
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithAdditionalClass()),
+            $this->filter($this->generateRenderedArea('container', $elements))
+        );
+    }
+
+    private function getCompareDefault()
+    {
+        return '<div class="toolbox-element toolbox-container ">
+                    <div class="container">
+                        <div class="container-inner"></div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareWithFullWidth()
+    {
+        return '<div class="toolbox-element toolbox-container ">
+                    <div class="container-fluid">
+                        <div class="container-inner"></div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareWithAdditionalClass()
+    {
+        return '<div class="toolbox-element toolbox-container additional-class">
+                    <div class="container">
+                        <div class="container-inner"></div>
+                    </div>
+                </div>';
+    }
+}

--- a/tests/bundle_tests/unit_areas/ContainerTest.php
+++ b/tests/bundle_tests/unit_areas/ContainerTest.php
@@ -10,6 +10,20 @@ use Pimcore\Tests\Util\TestHelper;
 
 class ContainerTest extends AbstractAreaTest
 {
+    const TYPE = 'container';
+
+    public function testContainerBackendConfig()
+    {
+        $this->setupRequest();
+
+        $areaConfig = $this->generateBackendArea(self::TYPE);
+        $configElements = $areaConfig['config_elements'];
+
+        $this->assertCount(1, $configElements);
+        $this->assertEquals('checkbox', $configElements[0]['additional_config']['type']);
+        $this->assertEquals('full_width_container', $configElements[0]['additional_config']['name']);
+    }
+
     public function testImage()
     {
         $this->setupRequest();
@@ -19,7 +33,7 @@ class ContainerTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareDefault()),
-            $this->filter($this->generateRenderedArea('container', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -36,7 +50,7 @@ class ContainerTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithFullWidth()),
-            $this->filter($this->generateRenderedArea('container', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
 
     }
@@ -54,7 +68,7 @@ class ContainerTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithAdditionalClass()),
-            $this->filter($this->generateRenderedArea('container', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 

--- a/tests/bundle_tests/unit_areas/ContentTest.php
+++ b/tests/bundle_tests/unit_areas/ContentTest.php
@@ -6,6 +6,18 @@ use Pimcore\Model\Document\Tag\Select;
 
 class ContentTest extends AbstractAreaTest
 {
+    const TYPE = 'content';
+
+    public function testContentBackendConfig()
+    {
+        $this->setupRequest();
+
+        $areaConfig = $this->generateBackendArea(self::TYPE);
+        $configElements = $areaConfig['config_elements'];
+
+        $this->assertCount(0, $configElements);
+    }
+
     public function testContent()
     {
         $this->setupRequest();
@@ -14,11 +26,11 @@ class ContentTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompare()),
-            $this->filter($this->generateRenderedArea('content', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
-     public function testContentWithAdditionalClass()
+    public function testContentWithAdditionalClass()
     {
         $this->setupRequest();
 
@@ -31,7 +43,7 @@ class ContentTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithAdditionalClass()),
-            $this->filter($this->generateRenderedArea('content', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 

--- a/tests/bundle_tests/unit_areas/ContentTest.php
+++ b/tests/bundle_tests/unit_areas/ContentTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace DachcomBundle\Test\Unit;
+
+use Pimcore\Model\Document\Tag\Select;
+
+class ContentTest extends AbstractAreaTest
+{
+    public function testContent()
+    {
+        $this->setupRequest();
+
+        $elements = [];
+
+        $this->assertEquals(
+            $this->filter($this->getCompare()),
+            $this->filter($this->generateRenderedArea('content', $elements))
+        );
+    }
+
+     public function testContentWithAdditionalClass()
+    {
+        $this->setupRequest();
+
+        $combo = new Select();
+        $combo->setDataFromResource('additional-class');
+
+        $elements = [
+            'add_classes' => $combo
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithAdditionalClass()),
+            $this->filter($this->generateRenderedArea('content', $elements))
+        );
+    }
+
+    private function getCompare()
+    {
+        return '<div class="toolbox-element toolbox-content wysiwyg content-container "></div>';
+    }
+
+    private function getCompareWithAdditionalClass()
+    {
+        return '<div class="toolbox-element toolbox-content wysiwyg content-container additional-class"></div>';
+    }
+}

--- a/tests/bundle_tests/unit_areas/DownloadTest.php
+++ b/tests/bundle_tests/unit_areas/DownloadTest.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace DachcomBundle\Test\Unit;
+
+use Pimcore\Model\Document\Tag\Checkbox;
+use Pimcore\Model\Document\Tag\Multihref;
+use Pimcore\Model\Document\Tag\Select;
+use Pimcore\Tests\Util\TestHelper;
+
+class DownloadTest extends AbstractAreaTest
+{
+    public function testDownload()
+    {
+        $this->setupRequest();
+
+        $asset1 = TestHelper::createImageAsset('', true);
+        $asset2 = TestHelper::createImageAsset('', true);
+
+        $downloads = new Multihref();
+        $downloads->setDataFromEditmode([
+            [
+                'id'   => $asset1->getId(),
+                'type' => 'asset'
+            ],
+            [
+                'id'   => $asset2->getId(),
+                'type' => 'asset'
+            ]
+        ]);
+
+        $elements = [
+            'downloads' => $downloads
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompare($asset1->getFullPath(), $asset2->getFullPath())),
+            $this->filter($this->generateRenderedArea('download', $elements))
+        );
+    }
+
+    public function testDownloadWithPreviewImage()
+    {
+        $this->setupRequest();
+
+        $asset1 = TestHelper::createImageAsset('', true);
+        $asset2 = TestHelper::createImageAsset('', true);
+
+        $downloads = new Multihref();
+        $downloads->setDataFromEditmode([
+            [
+                'id'   => $asset1->getId(),
+                'type' => 'asset'
+            ],
+            [
+                'id'   => $asset2->getId(),
+                'type' => 'asset'
+            ]
+        ]);
+
+        $checkbox = new Checkbox();
+        $checkbox->setDataFromResource(1);
+
+        $elements = [
+            'downloads' => $downloads,
+            'show_preview_images' => $checkbox
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithPreviewImage($asset1->getFullPath(), $asset2->getFullPath())),
+            $this->filter($this->generateRenderedArea('download', $elements))
+        );
+    }
+
+
+    public function testDownloadWithFileInfo()
+    {
+        $this->setupRequest();
+
+        $asset1 = TestHelper::createImageAsset('', true);
+        $asset2 = TestHelper::createImageAsset('', true);
+
+        $downloads = new Multihref();
+        $downloads->setDataFromEditmode([
+            [
+                'id'   => $asset1->getId(),
+                'type' => 'asset'
+            ],
+            [
+                'id'   => $asset2->getId(),
+                'type' => 'asset'
+            ]
+        ]);
+
+        $checkbox = new Checkbox();
+        $checkbox->setDataFromResource(1);
+
+        $elements = [
+            'downloads' => $downloads,
+            'show_file_info' => $checkbox
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithFileInfo($asset1->getFullPath(), $asset2->getFullPath())),
+            $this->filter($this->generateRenderedArea('download', $elements))
+        );
+    }
+
+    public function testDownloadWithAdditionalClass()
+    {
+        $this->setupRequest();
+
+        $asset1 = TestHelper::createImageAsset('', true);
+        $asset2 = TestHelper::createImageAsset('', true);
+
+        $downloads = new Multihref();
+        $downloads->setDataFromEditmode([
+            [
+                'id'   => $asset1->getId(),
+                'type' => 'asset'
+            ],
+            [
+                'id'   => $asset2->getId(),
+                'type' => 'asset'
+            ]
+        ]);
+
+        $combo = new Select();
+        $combo->setDataFromResource('additional-class');
+
+        $elements = [
+            'downloads' => $downloads,
+            'add_classes' => $combo
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithAdditionalClass($asset1->getFullPath(), $asset2->getFullPath())),
+            $this->filter($this->generateRenderedArea('download', $elements))
+        );
+    }
+
+    private function getCompare($path1, $path2)
+    {
+        return '<div class="toolbox-element toolbox-download ">
+                    <div class="download-list">
+                        <ul class="list-unstyled">
+                            <li>
+                                <a href="' . $path1 . '"  target="_blank" class="icon-download-jpg">
+                                    <span class="title">Download</span>
+                                </a>
+                            </li>
+                            <li>
+                                <a href="' . $path2 . '"  target="_blank" class="icon-download-jpg">
+                                    <span class="title">Download</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareWithPreviewImage($path1, $path2)
+    {
+        return '<div class="toolbox-element toolbox-download ">
+                    <div class="download-list show-image-preview">
+                        <ul class="list-unstyled">
+                            <li>
+                                <a href="' . $path1 . '"  target="_blank" class="icon-download-jpg">
+                                    <span class="preview-image"><img src="' . $path1 . '" alt="Download"/></span>
+                                    <span class="title">Download</span>
+                                </a>
+                            </li>
+                            <li>
+                                <a href="' . $path2 . '"  target="_blank" class="icon-download-jpg">
+                                    <span class="preview-image"><img src="' . $path2 . '" alt="Download"/></span>
+                                    <span class="title">Download</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareWithFileInfo($path1, $path2)
+    {
+        return '<div class="toolbox-element toolbox-download ">
+                    <div class="download-list">
+                        <ul class="list-unstyled">
+                            <li>
+                                <a href="' . $path1 . '"  target="_blank" class="icon-download-jpg">
+                                    <span class="title">Download</span>
+                                    <span class="file-info">(<span class="file-type">jpg</span>, 1 byte)</span>
+                                </a>
+                            </li>
+                            <li>
+                                <a href="' . $path2 . '"  target="_blank" class="icon-download-jpg">
+                                    <span class="title">Download</span>
+                                    <span class="file-info">(<span class="file-type">jpg</span>, 1 byte)</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareWithAdditionalClass($path1, $path2)
+    {
+        return '<div class="toolbox-element toolbox-download additional-class">
+                    <div class="download-list">
+                        <ul class="list-unstyled">
+                            <li>
+                                <a href="' . $path1 . '"  target="_blank" class="icon-download-jpg">
+                                    <span class="title">Download</span>
+                                </a>
+                            </li>
+                            <li>
+                                <a href="' . $path2 . '"  target="_blank" class="icon-download-jpg">
+                                    <span class="title">Download</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>';
+    }
+}

--- a/tests/bundle_tests/unit_areas/DownloadTest.php
+++ b/tests/bundle_tests/unit_areas/DownloadTest.php
@@ -9,6 +9,26 @@ use Pimcore\Tests\Util\TestHelper;
 
 class DownloadTest extends AbstractAreaTest
 {
+    const TYPE = 'download';
+
+    public function testDownloadBackendConfig()
+    {
+        $this->setupRequest();
+
+        $areaConfig = $this->generateBackendArea(self::TYPE);
+        $configElements = $areaConfig['config_elements'];
+
+        $this->assertCount(3, $configElements);
+        $this->assertEquals('multihref', $configElements[0]['additional_config']['type']);
+        $this->assertEquals('downloads', $configElements[0]['additional_config']['name']);
+
+        $this->assertEquals('checkbox', $configElements[1]['additional_config']['type']);
+        $this->assertEquals('show_preview_images', $configElements[1]['additional_config']['name']);
+
+        $this->assertEquals('checkbox', $configElements[2]['additional_config']['type']);
+        $this->assertEquals('show_file_info', $configElements[2]['additional_config']['name']);
+    }
+
     public function testDownload()
     {
         $this->setupRequest();
@@ -34,7 +54,7 @@ class DownloadTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompare($asset1->getFullPath(), $asset2->getFullPath())),
-            $this->filter($this->generateRenderedArea('download', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -61,16 +81,15 @@ class DownloadTest extends AbstractAreaTest
         $checkbox->setDataFromResource(1);
 
         $elements = [
-            'downloads' => $downloads,
+            'downloads'           => $downloads,
             'show_preview_images' => $checkbox
         ];
 
         $this->assertEquals(
             $this->filter($this->getCompareWithPreviewImage($asset1->getFullPath(), $asset2->getFullPath())),
-            $this->filter($this->generateRenderedArea('download', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
-
 
     public function testDownloadWithFileInfo()
     {
@@ -95,13 +114,13 @@ class DownloadTest extends AbstractAreaTest
         $checkbox->setDataFromResource(1);
 
         $elements = [
-            'downloads' => $downloads,
+            'downloads'      => $downloads,
             'show_file_info' => $checkbox
         ];
 
         $this->assertEquals(
             $this->filter($this->getCompareWithFileInfo($asset1->getFullPath(), $asset2->getFullPath())),
-            $this->filter($this->generateRenderedArea('download', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -128,13 +147,13 @@ class DownloadTest extends AbstractAreaTest
         $combo->setDataFromResource('additional-class');
 
         $elements = [
-            'downloads' => $downloads,
+            'downloads'   => $downloads,
             'add_classes' => $combo
         ];
 
         $this->assertEquals(
             $this->filter($this->getCompareWithAdditionalClass($asset1->getFullPath(), $asset2->getFullPath())),
-            $this->filter($this->generateRenderedArea('download', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 

--- a/tests/bundle_tests/unit_areas/GalleryTest.php
+++ b/tests/bundle_tests/unit_areas/GalleryTest.php
@@ -9,6 +9,26 @@ use Pimcore\Tests\Util\TestHelper;
 
 class GalleryTest extends AbstractAreaTest
 {
+    const TYPE = 'gallery';
+
+    public function testGalleryBackendConfig()
+    {
+        $this->setupRequest();
+
+        $areaConfig = $this->generateBackendArea(self::TYPE);
+        $configElements = $areaConfig['config_elements'];
+
+        $this->assertCount(3, $configElements);
+        $this->assertEquals('multihref', $configElements[0]['additional_config']['type']);
+        $this->assertEquals('images', $configElements[0]['additional_config']['name']);
+
+        $this->assertEquals('checkbox', $configElements[1]['additional_config']['type']);
+        $this->assertEquals('use_light_box', $configElements[1]['additional_config']['name']);
+
+        $this->assertEquals('checkbox', $configElements[2]['additional_config']['type']);
+        $this->assertEquals('use_thumbnails', $configElements[2]['additional_config']['name']);
+    }
+
     public function testGallery()
     {
         $this->setupRequest();
@@ -34,7 +54,7 @@ class GalleryTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompare($asset1->getFullPath(), $asset2->getFullPath())),
-            $this->filter($this->generateRenderedArea('gallery', $elements, ['toolboxGalleryId' => 'test']))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements, ['toolboxGalleryId' => 'test']))
         );
     }
 
@@ -67,7 +87,7 @@ class GalleryTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithLightBox($asset1->getFullPath(), $asset2->getFullPath())),
-            $this->filter($this->generateRenderedArea('gallery', $elements, ['toolboxGalleryId' => 'test']))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements, ['toolboxGalleryId' => 'test']))
         );
     }
 
@@ -100,7 +120,7 @@ class GalleryTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithThumbnails($asset1->getFullPath(), $asset2->getFullPath())),
-            $this->filter($this->generateRenderedArea('gallery', $elements, ['toolboxGalleryId' => 'test']))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements, ['toolboxGalleryId' => 'test']))
         );
     }
 
@@ -133,7 +153,7 @@ class GalleryTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithAdditionalClass($asset1, $asset2)),
-            $this->filter($this->generateRenderedArea('gallery', $elements, ['toolboxGalleryId' => 'test']))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements, ['toolboxGalleryId' => 'test']))
         );
     }
 

--- a/tests/bundle_tests/unit_areas/GalleryTest.php
+++ b/tests/bundle_tests/unit_areas/GalleryTest.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace DachcomBundle\Test\Unit;
+
+use Pimcore\Model\Document\Tag\Checkbox;
+use Pimcore\Model\Document\Tag\Multihref;
+use Pimcore\Model\Document\Tag\Select;
+use Pimcore\Tests\Util\TestHelper;
+
+class GalleryTest extends AbstractAreaTest
+{
+    public function testGallery()
+    {
+        $this->setupRequest();
+
+        $asset1 = TestHelper::createImageAsset('', true);
+        $asset2 = TestHelper::createImageAsset('', true);
+
+        $images = new Multihref();
+        $images->setDataFromEditmode([
+            [
+                'id'   => $asset1->getId(),
+                'type' => 'asset'
+            ],
+            [
+                'id'   => $asset2->getId(),
+                'type' => 'asset'
+            ]
+        ]);
+
+        $elements = [
+            'images' => $images
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompare($asset1->getFullPath(), $asset2->getFullPath())),
+            $this->filter($this->generateRenderedArea('gallery', $elements, ['toolboxGalleryId' => 'test']))
+        );
+    }
+
+    public function testGalleryWithLightBox()
+    {
+        $this->setupRequest();
+
+        $asset1 = TestHelper::createImageAsset('', true);
+        $asset2 = TestHelper::createImageAsset('', true);
+
+        $images = new Multihref();
+        $images->setDataFromEditmode([
+            [
+                'id'   => $asset1->getId(),
+                'type' => 'asset'
+            ],
+            [
+                'id'   => $asset2->getId(),
+                'type' => 'asset'
+            ]
+        ]);
+
+        $checkbox = new Checkbox();
+        $checkbox->setDataFromResource(1);
+
+        $elements = [
+            'images'        => $images,
+            'use_light_box' => $checkbox
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithLightBox($asset1->getFullPath(), $asset2->getFullPath())),
+            $this->filter($this->generateRenderedArea('gallery', $elements, ['toolboxGalleryId' => 'test']))
+        );
+    }
+
+    public function testGalleryWithThumbnails()
+    {
+        $this->setupRequest();
+
+        $asset1 = TestHelper::createImageAsset('', true);
+        $asset2 = TestHelper::createImageAsset('', true);
+
+        $images = new Multihref();
+        $images->setDataFromEditmode([
+            [
+                'id'   => $asset1->getId(),
+                'type' => 'asset'
+            ],
+            [
+                'id'   => $asset2->getId(),
+                'type' => 'asset'
+            ]
+        ]);
+
+        $checkbox = new Checkbox();
+        $checkbox->setDataFromResource(1);
+
+        $elements = [
+            'images'         => $images,
+            'use_thumbnails' => $checkbox
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithThumbnails($asset1->getFullPath(), $asset2->getFullPath())),
+            $this->filter($this->generateRenderedArea('gallery', $elements, ['toolboxGalleryId' => 'test']))
+        );
+    }
+
+    public function testGalleryWithAdditionalClass()
+    {
+        $this->setupRequest();
+
+        $combo = new Select();
+        $combo->setDataFromResource('additional-class');
+
+        $asset1 = TestHelper::createImageAsset('', true);
+        $asset2 = TestHelper::createImageAsset('', true);
+
+        $images = new Multihref();
+        $images->setDataFromEditmode([
+            [
+                'id'   => $asset1->getId(),
+                'type' => 'asset'
+            ],
+            [
+                'id'   => $asset2->getId(),
+                'type' => 'asset'
+            ]
+        ]);
+
+        $elements = [
+            'images'      => $images,
+            'add_classes' => $combo
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithAdditionalClass($asset1, $asset2)),
+            $this->filter($this->generateRenderedArea('gallery', $elements, ['toolboxGalleryId' => 'test']))
+        );
+    }
+
+    private function getCompare($path1, $path2)
+    {
+        return '<div class="toolbox-element toolbox-gallery ">
+                    <div class="row">
+                        <div class="col-12 col-gallery">
+                            <ul class="slick-slider list-unstyled  test-gal responsive-dots "                        data-lazy-load="false" data-fade="false" data-variable-width="false" data-autoplay="false" data-slides-to-show="1" data-dots="false" data-arrows="true"    >
+                                <li class="slide item">
+                                    <img alt="" src="' . $path1 . '" />
+                                </li>
+                                <li class="slide item">
+                                    <img alt="" src="' . $path2 . '" />
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareWithLightBox($path1, $path2)
+    {
+        return '<div class="toolbox-element toolbox-gallery ">
+                    <div class="row">
+                        <div class="col-12 col-gallery">
+                            <ul class="slick-slider list-unstyled  test-gal responsive-dots light-box"                        data-lazy-load="false" data-fade="false" data-variable-width="false" data-autoplay="false" data-slides-to-show="1" data-dots="false" data-arrows="true"    >
+                                <li class="slide item"data-src="' . $path1 . '">
+                                    <img alt="" src="' . $path1 . '" />
+                                </li>
+                                <li class="slide item"data-src="' . $path2 . '">
+                                    <img alt="" src="' . $path2 . '" />
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareWithThumbnails($path1, $path2)
+    {
+        return '<div class="toolbox-element toolbox-gallery ">
+                    <div class="row">
+                        <div class="col-12 col-gallery">
+                            <ul class="slick-slider list-unstyled thumbnail-slider test-gal responsive-dots "            data-as-nav-for=".test-thumbs"            data-lazy-load="false" data-fade="false" data-variable-width="false" data-autoplay="false" data-slides-to-show="1" data-dots="false" data-arrows="true"    >
+                                <li class="slide item">
+                                    <img alt="" src="' . $path1 . '" />
+                                </li>
+                                <li class="slide item">
+                                    <img alt="" src="' . $path2 . '" />
+                                </li>
+                            </ul>
+                            <ul class="slick-slider slick-slider-thumbs list-unstyled test-thumbs"            data-lazy-load="false" data-fade="false" data-variable-width="false" data-autoplay="false" data-slides-to-show="5" data-dots="false" data-arrows="true" data-center-mode="true"            data-as-nav-for=".test-gal"        >
+                                <li class="slide">
+                                    <img alt="" src="' . $path1 . '" />
+                                </li>
+                                <li class="slide">
+                                    <img alt="" src="' . $path2 . '" />
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareWithAdditionalClass($path1, $path2)
+    {
+        return '<div class="toolbox-element toolbox-gallery additional-class">
+                    <div class="row">
+                        <div class="col-12 col-gallery">
+                            <ul class="slick-slider list-unstyled  test-gal responsive-dots "                        data-lazy-load="false" data-fade="false" data-variable-width="false" data-autoplay="false" data-slides-to-show="1" data-dots="false" data-arrows="true"    >
+                                <li class="slide item">
+                                    <img alt="" src="' . $path1 . '" />
+                                </li>
+                                <li class="slide item">
+                                    <img alt="" src="' . $path2 . '" />
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>';
+    }
+}

--- a/tests/bundle_tests/unit_areas/GoogleMapTest.php
+++ b/tests/bundle_tests/unit_areas/GoogleMapTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace DachcomBundle\Test\Unit;
+
+use Pimcore\Model\Document\Tag\Checkbox;
+use Pimcore\Model\Document\Tag\Multihref;
+use Pimcore\Model\Document\Tag\Numeric;
+use Pimcore\Model\Document\Tag\Select;
+use Pimcore\Tests\Util\TestHelper;
+use ToolboxBundle\Model\Document\Tag\GoogleMap;
+
+class GoogleMapTest extends AbstractAreaTest
+{
+    public function testGoogleMap()
+    {
+        $this->setupRequest();
+
+        $googleMapElement = new GoogleMap();
+        $googleMapElement->setId('test');
+        $googleMapElement->disableGoogleLookup();
+
+        $googleMapElement->setDataFromEditmode([
+            [
+                'street' => 'Rorschacherstrasse 15',
+                'zip' => '9424',
+                'city' => 'Rheineck',
+                'country' => 'Schweiz'
+            ]
+        ]);
+
+        $mapZoom = new Numeric();
+        $mapZoom->setDataFromResource(5);
+
+        $mapType = new Select();
+        $mapZoom->setDataFromResource('roadmap');
+
+        $iwOnInit = new Checkbox();
+        $iwOnInit->setDataFromResource(1);
+
+        $iwOnInit = new Checkbox();
+        $iwOnInit->setDataFromResource(1);
+
+        $elements = [
+            'googlemap' => $googleMapElement,
+            'map_zoom' => $mapZoom,
+            'map_type' => $mapType,
+            'iw_on_init' => $iwOnInit
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompare()),
+            $this->filter($this->generateRenderedArea('googleMap', $elements))
+        );
+    }
+
+    public function testGoogleMapWidthAdditionalClasses()
+    {
+        $this->setupRequest();
+
+        $googleMapElement = new GoogleMap();
+        $googleMapElement->setId('test');
+        $googleMapElement->disableGoogleLookup();
+
+        $googleMapElement->setDataFromEditmode([
+            [
+                'street' => 'Rorschacherstrasse 15',
+                'zip' => '9424',
+                'city' => 'Rheineck',
+                'country' => 'Schweiz'
+            ]
+        ]);
+
+        $mapZoom = new Numeric();
+        $mapZoom->setDataFromResource(5);
+
+        $mapType = new Select();
+        $mapZoom->setDataFromResource('roadmap');
+
+        $iwOnInit = new Checkbox();
+        $iwOnInit->setDataFromResource(1);
+
+        $iwOnInit = new Checkbox();
+        $iwOnInit->setDataFromResource(1);
+
+        $iwOnInit = new Checkbox();
+        $iwOnInit->setDataFromResource(1);
+
+        $combo = new Select();
+        $combo->setDataFromResource('additional-class');
+
+        $elements = [
+            'googlemap' => $googleMapElement,
+            'map_zoom' => $mapZoom,
+            'map_type' => $mapType,
+            'iw_on_init' => $iwOnInit,
+            'add_classes' => $combo
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithAdditionalClasses()),
+            $this->filter($this->generateRenderedArea('googleMap', $elements))
+        );
+    }
+
+    private function getCompare()
+    {
+        return '<div class="toolbox-element toolbox-google-map ">
+                    <div class="toolbox-google-map-container">
+                        <div class="embed-responsive-item toolbox-googlemap" id="test" data-locations=\'[{"street":"Rorschacherstrasse 15","zip":"9424","city":"Rheineck","country":"Schweiz"}]\' data-show-info-window-on-load=\'1\' data-mapoption-zoom=\'roadmap\' data-mapoption-map-type-id=\'\' data-mapoption-street-view-control=\'true\' data-mapoption-map-type-control=\'false\' data-mapoption-pan-control=\'false\' data-mapoption-scrollwheel=\'false\'></div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareWithAdditionalClasses()
+    {
+        return '<div class="toolbox-element toolbox-google-map additional-class">
+                    <div class="toolbox-google-map-container">
+                        <div class="embed-responsive-item toolbox-googlemap" id="test" data-locations=\'[{"street":"Rorschacherstrasse 15","zip":"9424","city":"Rheineck","country":"Schweiz"}]\' data-show-info-window-on-load=\'1\' data-mapoption-zoom=\'roadmap\' data-mapoption-map-type-id=\'\' data-mapoption-street-view-control=\'true\' data-mapoption-map-type-control=\'false\' data-mapoption-pan-control=\'false\' data-mapoption-scrollwheel=\'false\'></div>
+                    </div>
+                </div>';
+    }
+
+}

--- a/tests/bundle_tests/unit_areas/GoogleMapTest.php
+++ b/tests/bundle_tests/unit_areas/GoogleMapTest.php
@@ -9,6 +9,27 @@ use ToolboxBundle\Model\Document\Tag\GoogleMap;
 
 class GoogleMapTest extends AbstractAreaTest
 {
+    const TYPE = 'googleMap';
+
+    public function testGoogleMapBackendConfig()
+    {
+        $this->setupRequest();
+
+        $areaConfig = $this->generateBackendArea(self::TYPE);
+        $configElements = $areaConfig['config_elements'];
+
+        $this->assertCount(3, $configElements);
+        $this->assertEquals('numeric', $configElements[0]['additional_config']['type']);
+        $this->assertEquals('map_zoom', $configElements[0]['additional_config']['name']);
+
+        $this->assertEquals('select', $configElements[1]['additional_config']['type']);
+        $this->assertEquals('map_type', $configElements[1]['additional_config']['name']);
+
+        $this->assertEquals('checkbox', $configElements[2]['additional_config']['type']);
+        $this->assertEquals('iw_on_init', $configElements[2]['additional_config']['name']);
+
+    }
+
     public function testGoogleMapConfigParameter()
     {
         $configParam = $this->getToolboxConfig()->getAreaParameterConfig('googleMap');
@@ -66,11 +87,11 @@ class GoogleMapTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompare()),
-            $this->filter($this->generateRenderedArea('googleMap', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
-    public function testGoogleMapWidthAdditionalClasses()
+    public function testGoogleMapWidthAdditionalClass()
     {
         $this->setupRequest();
 
@@ -114,8 +135,8 @@ class GoogleMapTest extends AbstractAreaTest
         ];
 
         $this->assertEquals(
-            $this->filter($this->getCompareWithAdditionalClasses()),
-            $this->filter($this->generateRenderedArea('googleMap', $elements))
+            $this->filter($this->getCompareWithAdditionalClass()),
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -128,7 +149,7 @@ class GoogleMapTest extends AbstractAreaTest
                 </div>';
     }
 
-    private function getCompareWithAdditionalClasses()
+    private function getCompareWithAdditionalClass()
     {
         return '<div class="toolbox-element toolbox-google-map additional-class">
                     <div class="toolbox-google-map-container">

--- a/tests/bundle_tests/unit_areas/GoogleMapTest.php
+++ b/tests/bundle_tests/unit_areas/GoogleMapTest.php
@@ -3,14 +3,31 @@
 namespace DachcomBundle\Test\Unit;
 
 use Pimcore\Model\Document\Tag\Checkbox;
-use Pimcore\Model\Document\Tag\Multihref;
 use Pimcore\Model\Document\Tag\Numeric;
 use Pimcore\Model\Document\Tag\Select;
-use Pimcore\Tests\Util\TestHelper;
 use ToolboxBundle\Model\Document\Tag\GoogleMap;
 
 class GoogleMapTest extends AbstractAreaTest
 {
+    public function testGoogleMapConfigParameter()
+    {
+        $configParam = $this->getToolboxConfig()->getAreaParameterConfig('googleMap');
+        $this->assertEquals(
+            [
+                'map_options'   => [
+                    'streetViewControl' => true,
+                    'mapTypeControl'    => false,
+                    'panControl'        => false,
+                    'scrollwheel'       => false
+                ],
+                'map_style_url' => false,
+                'marker_icon'   => false,
+                'map_api_key'   => '',
+            ],
+            $configParam
+        );
+    }
+
     public function testGoogleMap()
     {
         $this->setupRequest();
@@ -21,9 +38,9 @@ class GoogleMapTest extends AbstractAreaTest
 
         $googleMapElement->setDataFromEditmode([
             [
-                'street' => 'Rorschacherstrasse 15',
-                'zip' => '9424',
-                'city' => 'Rheineck',
+                'street'  => 'Rorschacherstrasse 15',
+                'zip'     => '9424',
+                'city'    => 'Rheineck',
                 'country' => 'Schweiz'
             ]
         ]);
@@ -41,9 +58,9 @@ class GoogleMapTest extends AbstractAreaTest
         $iwOnInit->setDataFromResource(1);
 
         $elements = [
-            'googlemap' => $googleMapElement,
-            'map_zoom' => $mapZoom,
-            'map_type' => $mapType,
+            'googlemap'  => $googleMapElement,
+            'map_zoom'   => $mapZoom,
+            'map_type'   => $mapType,
             'iw_on_init' => $iwOnInit
         ];
 
@@ -63,9 +80,9 @@ class GoogleMapTest extends AbstractAreaTest
 
         $googleMapElement->setDataFromEditmode([
             [
-                'street' => 'Rorschacherstrasse 15',
-                'zip' => '9424',
-                'city' => 'Rheineck',
+                'street'  => 'Rorschacherstrasse 15',
+                'zip'     => '9424',
+                'city'    => 'Rheineck',
                 'country' => 'Schweiz'
             ]
         ]);
@@ -89,10 +106,10 @@ class GoogleMapTest extends AbstractAreaTest
         $combo->setDataFromResource('additional-class');
 
         $elements = [
-            'googlemap' => $googleMapElement,
-            'map_zoom' => $mapZoom,
-            'map_type' => $mapType,
-            'iw_on_init' => $iwOnInit,
+            'googlemap'   => $googleMapElement,
+            'map_zoom'    => $mapZoom,
+            'map_type'    => $mapType,
+            'iw_on_init'  => $iwOnInit,
             'add_classes' => $combo
         ];
 

--- a/tests/bundle_tests/unit_areas/HeadlineTest.php
+++ b/tests/bundle_tests/unit_areas/HeadlineTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace DachcomBundle\Test\Unit;
+
+use Pimcore\Model\Document\Tag\Input;
+use Pimcore\Model\Document\Tag\Select;
+
+class HeadlineTest extends AbstractAreaTest
+{
+    public function testHeadline()
+    {
+        $this->setupRequest();
+
+        $headlineType = new Select();
+        $headlineType->setDataFromResource('h6');
+
+        $headlineText = new Input();
+        $headlineText->setDataFromResource('this is a headline');
+
+        $elements = [
+            'headline_type' => $headlineType,
+            'headline_text' => $headlineText
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompare()),
+            $this->filter($this->generateRenderedArea('headline', $elements))
+        );
+    }
+
+    public function testHeadlineWithAnchorName()
+    {
+        $this->setupRequest();
+
+        $headlineType = new Select();
+        $headlineType->setDataFromResource('h6');
+
+        $headlineText = new Input();
+        $headlineText->setDataFromResource('this is a headline');
+
+        $anchorName = new Input();
+        $anchorName->setDataFromResource('anchorName');
+
+        $elements = [
+            'headline_type' => $headlineType,
+            'headline_text' => $headlineText,
+            'anchor_name'   => $anchorName
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithAnchorName()),
+            $this->filter($this->generateRenderedArea('headline', $elements))
+        );
+    }
+
+    public function testHeadlineWithAdditionalClass()
+    {
+        $this->setupRequest();
+
+        $combo = new Select();
+        $combo->setDataFromResource('additional-class');
+
+        $headlineType = new Select();
+        $headlineType->setDataFromResource('h6');
+
+        $headlineText = new Input();
+        $headlineText->setDataFromResource('this is a headline');
+
+        $elements = [
+            'headline_type' => $headlineType,
+            'headline_text' => $headlineText,
+            'add_classes'   => $combo
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithAdditionalClass()),
+            $this->filter($this->generateRenderedArea('headline', $elements))
+        );
+    }
+
+    private function getCompare()
+    {
+        return '<div class="toolbox-element toolbox-headline "><h6>this is a headline</h6></div>';
+    }
+
+    private function getCompareWithAnchorName()
+    {
+        return '<div class="toolbox-element toolbox-headline "><a class="toolbox-anchor" id="anchorname"></a><h6>this is a headline</h6></div>';
+    }
+
+    private function getCompareWithAdditionalClass()
+    {
+        return '<div class="toolbox-element toolbox-headline additional-class"><h6>this is a headline</h6></div>';
+    }
+}

--- a/tests/bundle_tests/unit_areas/HeadlineTest.php
+++ b/tests/bundle_tests/unit_areas/HeadlineTest.php
@@ -7,6 +7,23 @@ use Pimcore\Model\Document\Tag\Select;
 
 class HeadlineTest extends AbstractAreaTest
 {
+    const TYPE = 'headline';
+
+    public function testHeadlineBackendConfig()
+    {
+        $this->setupRequest();
+
+        $areaConfig = $this->generateBackendArea(self::TYPE);
+        $configElements = $areaConfig['config_elements'];
+
+        $this->assertCount(2, $configElements);
+        $this->assertEquals('select', $configElements[0]['additional_config']['type']);
+        $this->assertEquals('headline_type', $configElements[0]['additional_config']['name']);
+
+        $this->assertEquals('input', $configElements[1]['additional_config']['type']);
+        $this->assertEquals('anchor_name', $configElements[1]['additional_config']['name']);
+    }
+
     public function testHeadline()
     {
         $this->setupRequest();
@@ -24,7 +41,7 @@ class HeadlineTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompare()),
-            $this->filter($this->generateRenderedArea('headline', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -49,7 +66,7 @@ class HeadlineTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithAnchorName()),
-            $this->filter($this->generateRenderedArea('headline', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -74,7 +91,7 @@ class HeadlineTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithAdditionalClass()),
-            $this->filter($this->generateRenderedArea('headline', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 

--- a/tests/bundle_tests/unit_areas/IframeTest.php
+++ b/tests/bundle_tests/unit_areas/IframeTest.php
@@ -8,6 +8,23 @@ use Pimcore\Model\Document\Tag\Select;
 
 class IframeTest extends AbstractAreaTest
 {
+    const TYPE = 'iFrame';
+
+    public function testIframeBackendConfig()
+    {
+        $this->setupRequest();
+
+        $areaConfig = $this->generateBackendArea(self::TYPE);
+        $configElements = $areaConfig['config_elements'];
+
+        $this->assertCount(2, $configElements);
+        $this->assertEquals('input', $configElements[0]['additional_config']['type']);
+        $this->assertEquals('url', $configElements[0]['additional_config']['name']);
+
+        $this->assertEquals('numeric', $configElements[1]['additional_config']['type']);
+        $this->assertEquals('iheight', $configElements[1]['additional_config']['name']);
+    }
+
     public function testIframe()
     {
         $this->setupRequest();
@@ -21,7 +38,7 @@ class IframeTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompare()),
-            $this->filter($this->generateRenderedArea('iFrame', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -42,7 +59,7 @@ class IframeTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithHeight()),
-            $this->filter($this->generateRenderedArea('iFrame', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -59,7 +76,7 @@ class IframeTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithAdditionalClass()),
-            $this->filter($this->generateRenderedArea('iFrame', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 

--- a/tests/bundle_tests/unit_areas/IframeTest.php
+++ b/tests/bundle_tests/unit_areas/IframeTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace DachcomBundle\Test\Unit;
+
+use Pimcore\Model\Document\Tag\Input;
+use Pimcore\Model\Document\Tag\Numeric;
+use Pimcore\Model\Document\Tag\Select;
+
+class IframeTest extends AbstractAreaTest
+{
+    public function testIframe()
+    {
+        $this->setupRequest();
+
+        $url = new Input();
+        $url->setDataFromResource('https://www.dachcom.com');
+
+        $elements = [
+            'url' => $url
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompare()),
+            $this->filter($this->generateRenderedArea('iFrame', $elements))
+        );
+    }
+
+    public function testIframeWithHeight()
+    {
+        $this->setupRequest();
+
+        $url = new Input();
+        $url->setDataFromResource('https://www.dachcom.com');
+
+        $height = new Numeric();
+        $height->setDataFromResource(200);
+
+        $elements = [
+            'url'     => $url,
+            'iheight' => $height
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithHeight()),
+            $this->filter($this->generateRenderedArea('iFrame', $elements))
+        );
+    }
+
+    public function testIframeWithAdditionalClass()
+    {
+        $this->setupRequest();
+
+        $combo = new Select();
+        $combo->setDataFromResource('additional-class');
+
+        $elements = [
+            'add_classes' => $combo
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithAdditionalClass()),
+            $this->filter($this->generateRenderedArea('iFrame', $elements))
+        );
+    }
+
+    private function getCompare()
+    {
+        return '<div class="toolbox-element toolbox-iframe ">
+                    <iframe src="https://www.dachcom.com" frameborder="0" width="100%" ></iframe>
+                </div>';
+    }
+
+    private function getCompareWithHeight()
+    {
+        return '<div class="toolbox-element toolbox-iframe ">
+                    <iframe src="https://www.dachcom.com" frameborder="0" width="100%" height="200px"></iframe>
+                </div>';
+    }
+
+    private function getCompareWithAdditionalClass()
+    {
+        return '<div class="toolbox-element toolbox-iframe additional-class">
+                    <iframe src="" frameborder="0" width="100%" ></iframe>
+                </div>';
+    }
+}

--- a/tests/bundle_tests/unit_areas/ImageTest.php
+++ b/tests/bundle_tests/unit_areas/ImageTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace DachcomBundle\Test\Unit;
+
+use Pimcore\Model\Document\Tag\Checkbox;
+use Pimcore\Model\Document\Tag\Image;
+use Pimcore\Model\Document\Tag\Link;
+use Pimcore\Model\Document\Tag\Select;
+use Pimcore\Tests\Util\TestHelper;
+
+class ImageTest extends AbstractAreaTest
+{
+    public function testImage()
+    {
+        $this->setupRequest();
+
+        $asset = TestHelper::createImageAsset('', true);
+
+        $imageTag = new Image();
+        $imageTag->setImage($asset);
+        $imageTag->setText('caption');
+
+        $elements = [
+            'ci' => $imageTag
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareDefault($asset->getFullPath())),
+            $this->filter($this->generateRenderedArea('image', $elements))
+        );
+    }
+
+    public function testImageWithCaption()
+    {
+        $this->setupRequest();
+
+        $asset = TestHelper::createImageAsset('', true);
+
+        $imageTag = new Image();
+        $imageTag->setImage($asset);
+        $imageTag->setText('caption');
+
+        $checkbox = new Checkbox();
+        $checkbox->setDataFromResource(1);
+
+        $elements = [
+            'ci'           => $imageTag,
+            'show_caption' => $checkbox
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareCaption($asset->getFullPath())),
+            $this->filter($this->generateRenderedArea('image', $elements))
+        );
+
+    }
+
+    public function testImageWithLightBox()
+    {
+        $this->setupRequest();
+
+        $asset = TestHelper::createImageAsset('', true);
+
+        $imageTag = new Image();
+        $imageTag->setImage($asset);
+        $imageTag->setText('caption');
+
+        $lightBox = new Checkbox();
+        $lightBox->setDataFromResource(1);
+
+        $elements = [
+            'ci'            => $imageTag,
+            'use_light_box' => $lightBox,
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareLightBox($asset->getFullPath())),
+            $this->filter($this->generateRenderedArea('image', $elements))
+        );
+    }
+
+    public function testImageWithLink()
+    {
+        $this->setupRequest();
+
+        $asset = TestHelper::createImageAsset('', true);
+
+        $imageTag = new Image();
+        $imageTag->setImage($asset);
+        $imageTag->setText('caption');
+
+        $link = new Link();
+        $link->setDataFromResource(['path' => '/test/test2']);
+
+        $elements = [
+            'ci'         => $imageTag,
+            'image_link' => $link,
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareLink($asset->getFullPath())),
+            $this->filter($this->generateRenderedArea('image', $elements))
+        );
+    }
+
+    public function testImageWithAdditionalClass()
+    {
+        $this->setupRequest();
+
+        $asset = TestHelper::createImageAsset('', true);
+
+        $imageTag = new Image();
+        $imageTag->setImage($asset);
+        $imageTag->setText('caption');
+
+        $combo = new Select();
+        $combo->setDataFromResource('additional-class');
+
+        $elements = [
+            'ci'          => $imageTag,
+            'add_classes' => $combo,
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithAdditionalClass($asset->getFullPath())),
+            $this->filter($this->generateRenderedArea('image', $elements))
+        );
+    }
+
+    private function getCompareDefault($fileName)
+    {
+        return '<div class="toolbox-element toolbox-image ">
+                    <div class="row">
+                        <div class="col-12">
+                            <div >
+                                <img alt="" src="' . $fileName . '" />
+                            </div>
+                        </div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareCaption($fileName)
+    {
+        return '<div class="toolbox-element toolbox-image ">
+                    <div class="row">
+                        <div class="col-12">
+                            <div >
+                                <img alt="" src="' . $fileName . '" />
+                                <span class="caption">caption</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareLightBox($fileName)
+    {
+        return '<div class="toolbox-element toolbox-image ">
+                    <div class="row">
+                        <div class="col-12">
+                            <div class="light-box">
+                                <a href="' . $fileName . '" class="item">
+                                    <img alt="" src="' . $fileName . '" />
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareLink($fileName)
+    {
+        return '<div class="toolbox-element toolbox-image ">
+                    <div class="row">
+                        <div class="col-12">
+                            <div >
+                                <a href="/test/test2" target="">
+                                    <img alt="" src="' . $fileName . '" />
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareWithAdditionalClass($fileName)
+    {
+        return '<div class="toolbox-element toolbox-image additional-class">
+                    <div class="row">
+                        <div class="col-12">
+                            <div >
+                                <img alt="" src="' . $fileName . '" />
+                            </div>
+                        </div>
+                    </div>
+                </div>';
+    }
+}

--- a/tests/bundle_tests/unit_areas/ImageTest.php
+++ b/tests/bundle_tests/unit_areas/ImageTest.php
@@ -10,6 +10,21 @@ use Pimcore\Tests\Util\TestHelper;
 
 class ImageTest extends AbstractAreaTest
 {
+    const TYPE = 'image';
+
+    public function testIframeBackendConfig()
+    {
+        $this->setupRequest();
+
+        $areaConfig = $this->generateBackendArea(self::TYPE);
+        $configElements = $areaConfig['config_elements'];
+
+        $this->assertCount(3, $configElements);
+        $this->assertEquals('link', $configElements[0]['additional_config']['type']);
+        $this->assertEquals('checkbox', $configElements[1]['additional_config']['type']);
+        $this->assertEquals('checkbox', $configElements[2]['additional_config']['type']);
+    }
+
     public function testImage()
     {
         $this->setupRequest();
@@ -26,7 +41,7 @@ class ImageTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareDefault($asset->getFullPath())),
-            $this->filter($this->generateRenderedArea('image', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -50,7 +65,7 @@ class ImageTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareCaption($asset->getFullPath())),
-            $this->filter($this->generateRenderedArea('image', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
 
     }
@@ -75,7 +90,7 @@ class ImageTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareLightBox($asset->getFullPath())),
-            $this->filter($this->generateRenderedArea('image', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -99,7 +114,7 @@ class ImageTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareLink($asset->getFullPath())),
-            $this->filter($this->generateRenderedArea('image', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -123,7 +138,7 @@ class ImageTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithAdditionalClass($asset->getFullPath())),
-            $this->filter($this->generateRenderedArea('image', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 

--- a/tests/bundle_tests/unit_areas/LinkListTest.php
+++ b/tests/bundle_tests/unit_areas/LinkListTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace DachcomBundle\Test\Unit;
+
+use Pimcore\Model\Document\Tag\Block;
+use Pimcore\Model\Document\Tag\Link;
+use Pimcore\Model\Document\Tag\Select;
+
+class LinkListTest extends AbstractAreaTest
+{
+    public function testLinkList()
+    {
+        $this->setupRequest();
+
+        $link1 = new Link();
+        $link1->setDataFromEditmode(['path' => 'https://www.dachcom.com']);
+
+        $link2 = new Link();
+        $link2->setDataFromEditmode(['path' => 'https://www.dachcom-digital.com']);
+
+        $block = new Block();
+        $block->setName('test-block-name');
+        $block->setDataFromEditmode([1, 2]);
+
+        $elements = [
+            'linklistblock'            => $block,
+            'linklistblock:1.linklist' => $link1,
+            'linklistblock:2.linklist' => $link2
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompare()),
+            $this->filter($this->generateRenderedArea('linkList', $elements))
+        );
+    }
+
+    public function testLinkListWithAdditionalClass()
+    {
+        $this->setupRequest();
+
+        $combo = new Select();
+        $combo->setDataFromResource('additional-class');
+
+        $link1 = new Link();
+        $link1->setDataFromEditmode(['path' => 'https://www.dachcom.com']);
+
+        $link2 = new Link();
+        $link2->setDataFromEditmode(['path' => 'https://www.dachcom-digital.com']);
+
+        $block = new Block();
+        $block->setName('test-block-name');
+        $block->setDataFromEditmode([1, 2]);
+
+        $elements = [
+            'linklistblock'            => $block,
+            'linklistblock:1.linklist' => $link1,
+            'linklistblock:2.linklist' => $link2,
+            'add_classes'              => $combo
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithAdditionalClass()),
+            $this->filter($this->generateRenderedArea('linkList', $elements))
+        );
+    }
+
+    private function getCompare()
+    {
+        return '<div class="toolbox-element toolbox-linklist ">
+                    <ul>
+                        <li>
+                            <a href="https://www.dachcom.com" class="list-link"></a>
+                        </li>
+                        <li>
+                            <a href="https://www.dachcom-digital.com" class="list-link"></a>
+                        </li>
+                    </ul>
+                </div>';
+    }
+
+    private function getCompareWithAdditionalClass()
+    {
+        return '<div class="toolbox-element toolbox-linklist additional-class">
+                    <ul>
+                        <li>
+                            <a href="https://www.dachcom.com" class="list-link"></a>
+                        </li>
+                        <li>
+                            <a href="https://www.dachcom-digital.com" class="list-link"></a>
+                        </li>
+                    </ul>
+                </div>';
+    }
+}

--- a/tests/bundle_tests/unit_areas/LinkListTest.php
+++ b/tests/bundle_tests/unit_areas/LinkListTest.php
@@ -8,6 +8,18 @@ use Pimcore\Model\Document\Tag\Select;
 
 class LinkListTest extends AbstractAreaTest
 {
+    const TYPE = 'linkList';
+
+    public function testLinkListBackendConfig()
+    {
+        $this->setupRequest();
+
+        $areaConfig = $this->generateBackendArea(self::TYPE);
+        $configElements = $areaConfig['config_elements'];
+
+        $this->assertCount(0, $configElements);
+    }
+
     public function testLinkList()
     {
         $this->setupRequest();
@@ -30,7 +42,7 @@ class LinkListTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompare()),
-            $this->filter($this->generateRenderedArea('linkList', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -60,7 +72,7 @@ class LinkListTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithAdditionalClass()),
-            $this->filter($this->generateRenderedArea('linkList', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 

--- a/tests/bundle_tests/unit_areas/ParallaxContainerSectionTest.php
+++ b/tests/bundle_tests/unit_areas/ParallaxContainerSectionTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace DachcomBundle\Test\Unit;
+
+class ParallaxContainerSectionTest extends AbstractAreaTest
+{
+    const TYPE = 'parallaxContainerSection';
+
+    public function testParallaxContainerSectionBackendConfig()
+    {
+        $this->setupRequest();
+
+        $areaConfig = $this->generateBackendArea(self::TYPE);
+        $configElements = $areaConfig['config_elements'];
+
+        $this->assertCount(4, $configElements);
+        $this->assertEquals('select', $configElements[0]['additional_config']['type']);
+        $this->assertEquals('template', $configElements[0]['additional_config']['name']);
+
+        $this->assertEquals('select', $configElements[1]['additional_config']['type']);
+        $this->assertEquals('container_type', $configElements[1]['additional_config']['name']);
+
+        $this->assertEquals('href', $configElements[2]['additional_config']['type']);
+        $this->assertEquals('background_image', $configElements[2]['additional_config']['name']);
+
+        $this->assertEquals('select', $configElements[3]['additional_config']['type']);
+        $this->assertEquals('background_color', $configElements[3]['additional_config']['name']);
+    }
+
+    public function testParallaxContainerConfigParameter()
+    {
+        $configParam = $this->getToolboxConfig()->getAreaParameterConfig(self::TYPE);
+        $this->assertEquals(
+            [
+                'background_image_mode' => 'data',
+                'background_color_mode' => 'data'
+            ],
+            $configParam
+        );
+    }
+}

--- a/tests/bundle_tests/unit_areas/ParallaxContainerTest.php
+++ b/tests/bundle_tests/unit_areas/ParallaxContainerTest.php
@@ -10,9 +10,35 @@ use ToolboxBundle\Model\Document\Tag\ParallaxImage;
 
 class ParallaxContainerTest extends AbstractAreaTest
 {
+    const TYPE = 'parallaxContainer';
+
+    public function testParallaxContainerBackendConfig()
+    {
+        $this->setupRequest();
+
+        $areaConfig = $this->generateBackendArea(self::TYPE);
+        $configElements = $areaConfig['config_elements'];
+
+        $this->assertCount(5, $configElements);
+        $this->assertEquals('select', $configElements[0]['additional_config']['type']);
+        $this->assertEquals('template', $configElements[0]['additional_config']['name']);
+
+        $this->assertEquals('href', $configElements[1]['additional_config']['type']);
+        $this->assertEquals('background_image', $configElements[1]['additional_config']['name']);
+
+        $this->assertEquals('select', $configElements[2]['additional_config']['type']);
+        $this->assertEquals('background_color', $configElements[2]['additional_config']['name']);
+
+        $this->assertEquals('parallaximage', $configElements[3]['additional_config']['type']);
+        $this->assertEquals('image_front', $configElements[3]['additional_config']['name']);
+
+        $this->assertEquals('parallaximage', $configElements[4]['additional_config']['type']);
+        $this->assertEquals('image_behind', $configElements[4]['additional_config']['name']);
+    }
+
     public function testParallaxContainerConfigParameter()
     {
-        $configParam = $this->getToolboxConfig()->getAreaParameterConfig('parallaxContainer');
+        $configParam = $this->getToolboxConfig()->getAreaParameterConfig(self::TYPE);
         $this->assertEquals(
             [
                 'window_size'           => 'large',
@@ -22,14 +48,40 @@ class ParallaxContainerTest extends AbstractAreaTest
             ],
             $configParam
         );
+    }
 
-        $configParam = $this->getToolboxConfig()->getAreaParameterConfig('parallaxContainerSection');
+    public function testParallaxContainer()
+    {
+        // wrap mode:
+
+        $this->setupRequest();
+
+        $asset = TestHelper::createImageAsset('', true);
+
+        $elements = $this->getDefaultElements($asset);
+
         $this->assertEquals(
-            [
-                'background_image_mode' => 'data',
-                'background_color_mode' => 'data'
-            ],
-            $configParam
+            $this->filter($this->getCompare($asset->getFullPath())),
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
+        );
+    }
+
+    public function testParallaxContainerWithAdditionalClass()
+    {
+        $this->setupRequest();
+
+        $asset = TestHelper::createImageAsset('', true);
+
+        $elements = $this->getDefaultElements($asset);
+
+        $combo = new Select();
+        $combo->setDataFromResource('additional-class');
+
+        $elements['add_classes'] = $combo;
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithAdditionalClass($asset->getFullPath())),
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -115,41 +167,6 @@ class ParallaxContainerTest extends AbstractAreaTest
             'pcB:2.background_color' => $sectionBackgroundColor
         ];
 
-    }
-
-    public function testParallaxContainer()
-    {
-        // wrap mode:
-
-        $this->setupRequest();
-
-        $asset = TestHelper::createImageAsset('', true);
-
-        $elements = $this->getDefaultElements($asset);
-
-        $this->assertEquals(
-            $this->filter($this->getCompare($asset->getFullPath())),
-            $this->filter($this->generateRenderedArea('parallaxContainer', $elements))
-        );
-    }
-
-    public function testParallaxContainerWithAdditionalClasses()
-    {
-        $this->setupRequest();
-
-        $asset = TestHelper::createImageAsset('', true);
-
-        $elements = $this->getDefaultElements($asset);
-
-        $combo = new Select();
-        $combo->setDataFromResource('additional-class');
-
-        $elements['add_classes'] = $combo;
-
-        $this->assertEquals(
-            $this->filter($this->getCompareWithAdditionalClass($asset->getFullPath())),
-            $this->filter($this->generateRenderedArea('parallaxContainer', $elements))
-        );
     }
 
     private function getCompare($imagePath)

--- a/tests/bundle_tests/unit_areas/ParallaxContainerTest.php
+++ b/tests/bundle_tests/unit_areas/ParallaxContainerTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace DachcomBundle\Test\Unit;
+
+use Pimcore\Model\Document\Tag\Block;
+use Pimcore\Model\Document\Tag\Href;
+use Pimcore\Model\Document\Tag\Select;
+use Pimcore\Tests\Util\TestHelper;
+use ToolboxBundle\Model\Document\Tag\ParallaxImage;
+
+class ParallaxContainerTest extends AbstractAreaTest
+{
+    private function getDefaultElements($asset)
+    {
+        $backgroundImage = new Href();
+        $backgroundImage->setDataFromEditmode([
+            'id'   => $asset->getId(),
+            'type' => 'asset'
+        ]);
+
+        $template = new Select();
+        $template->setDataFromEditmode('no-template');
+
+        $backgroundColor = new Select();
+        $backgroundColor->setDataFromEditmode('default');
+
+        $imageFront = new ParallaxImage();
+        $imageFront->setDataFromEditmode([
+            [
+                'id'               => $asset->getId(),
+                'type'             => 'asset',
+                'parallaxPosition' => 'top-left',
+                'parallaxSize'     => 'quarter-window-width'
+            ],
+            [
+                'id'               => $asset->getId(),
+                'type'             => 'asset',
+                'parallaxPosition' => 'top-left',
+                'parallaxSize'     => 'half-window-width'
+            ]
+        ]);
+
+        $imageBehind = new ParallaxImage();
+        $imageBehind->setDataFromEditmode([
+            [
+                'id'               => $asset->getId(),
+                'type'             => 'asset',
+                'parallaxPosition' => 'top-left',
+                'parallaxSize'     => 'third-window-width'
+            ],
+            [
+                'id'               => $asset->getId(),
+                'type'             => 'asset',
+                'parallaxPosition' => 'center-right',
+                'parallaxSize'     => 'half-window-width'
+            ]
+        ]);
+
+        $block = new Block();
+        $block->setName('test-parallax-container-section');
+        $block->setDataFromEditmode([1, 2]);
+
+        $sectionTemplate = new Select();
+        $sectionTemplate->setDataFromEditmode('no-template');
+
+        $sectionContainerType = new Select();
+        $sectionContainerType->setDataFromEditmode('container-fluid');
+
+        $sectionBackgroundImage = new Href();
+        $sectionBackgroundImage->setDataFromEditmode([
+            'id'   => $asset->getId(),
+            'type' => 'asset'
+        ]);
+
+        $sectionBackgroundColor = new Select();
+        $sectionBackgroundColor->setDataFromEditmode('no-background-color');
+
+        return [
+            'template'               => $template,
+            'background_image'       => $backgroundImage,
+            'background_color'       => $backgroundColor,
+            'image_front'            => $imageFront,
+            'image_behind'           => $imageBehind,
+            'pcB'                    => $block,
+            'pcB:1.template'         => $sectionTemplate,
+            'pcB:2.template'         => $sectionTemplate,
+            'pcB:1.container_type'   => $sectionContainerType,
+            'pcB:2.container_type'   => $sectionContainerType,
+            'pcB:1.background_image' => $sectionBackgroundImage,
+            'pcB:2.background_image' => $sectionBackgroundImage,
+            'pcB:1.background_color' => $sectionBackgroundColor,
+            'pcB:2.background_color' => $sectionBackgroundColor
+        ];
+
+    }
+
+    public function testParallaxContainer()
+    {
+        // wrap mode:
+
+        $this->setupRequest();
+
+        $asset = TestHelper::createImageAsset('', true);
+
+        $elements = $this->getDefaultElements($asset);
+
+        $this->assertEquals(
+            $this->filter($this->getCompare($asset->getFullPath())),
+            $this->filter($this->generateRenderedArea('parallaxContainer', $elements))
+        );
+    }
+
+    public function testParallaxContainerWithAdditionalClasses()
+    {
+        $this->setupRequest();
+
+        $asset = TestHelper::createImageAsset('', true);
+
+        $elements = $this->getDefaultElements($asset);
+
+        $combo = new Select();
+        $combo->setDataFromResource('additional-class');
+
+        $elements['add_classes'] = $combo;
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithAdditionalClass($asset->getFullPath())),
+            $this->filter($this->generateRenderedArea('parallaxContainer', $elements))
+        );
+    }
+
+    private function getCompare($imagePath)
+    {
+        return '<div class="toolbox-element toolbox-parallax-container template-no-template ">
+                    <div class="parallax-background " data-background-image="' . $imagePath . '" data-background-color="default">
+                        <div class="behind-elements">
+                            <div class="element position-top-left size-third-window-width"        data-background-image="' . $imagePath . '"        data-width="" data-height=""        data-element-position="top-left"        data-element-size="third-window-width"></div>
+                            <div class="element position-center-right size-half-window-width"        data-background-image="' . $imagePath . '"        data-width="" data-height=""        data-element-position="center-right"        data-element-size="half-window-width"></div>
+                        </div>
+                        <div class="parallax-content">
+                            <div class="parallax-section template-no-template " data-background-image="' . $imagePath . '" data-loop-index="1" data-section-index="1" data-template="no-template">
+                                <div class="toolbox-container">
+                                    <div class="container-fluid">
+                                        <div class="container-inner"></div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="parallax-section template-no-template " data-background-image="' . $imagePath . '" data-loop-index="2" data-section-index="2" data-template="no-template">
+                                <div class="toolbox-container">
+                                    <div class="container-fluid">
+                                        <div class="container-inner"></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="front-elements">
+                            <div class="element position-top-left size-quarter-window-width"        data-background-image="' . $imagePath . '"        data-width="" data-height=""        data-element-position="top-left"        data-element-size="quarter-window-width"></div>
+                            <div class="element position-top-left size-half-window-width"        data-background-image="' . $imagePath . '"        data-width="" data-height=""        data-element-position="top-left"        data-element-size="half-window-width"></div>
+                        </div>
+                    </div>
+                </div>';
+
+    }
+
+    private function getCompareWithAdditionalClass($imagePath)
+    {
+        return '<div class="toolbox-element toolbox-parallax-container template-no-template additional-class">
+                    <div class="parallax-background " data-background-image="' . $imagePath . '" data-background-color="default">
+                        <div class="behind-elements">
+                            <div class="element position-top-left size-third-window-width"        data-background-image="' . $imagePath . '"        data-width="" data-height=""        data-element-position="top-left"        data-element-size="third-window-width"></div>
+                            <div class="element position-center-right size-half-window-width"        data-background-image="' . $imagePath . '"        data-width="" data-height=""        data-element-position="center-right"        data-element-size="half-window-width"></div>
+                        </div>
+                        <div class="parallax-content">
+                            <div class="parallax-section template-no-template " data-background-image="' . $imagePath . '" data-loop-index="1" data-section-index="1" data-template="no-template">
+                                <div class="toolbox-container">
+                                    <div class="container-fluid">
+                                        <div class="container-inner"></div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="parallax-section template-no-template " data-background-image="' . $imagePath . '" data-loop-index="2" data-section-index="2" data-template="no-template">
+                                <div class="toolbox-container">
+                                    <div class="container-fluid">
+                                        <div class="container-inner"></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="front-elements">
+                            <div class="element position-top-left size-quarter-window-width"        data-background-image="' . $imagePath . '"        data-width="" data-height=""        data-element-position="top-left"        data-element-size="quarter-window-width"></div>
+                            <div class="element position-top-left size-half-window-width"        data-background-image="' . $imagePath . '"        data-width="" data-height=""        data-element-position="top-left"        data-element-size="half-window-width"></div>
+                        </div>
+                    </div>
+                </div>';
+
+    }
+}

--- a/tests/bundle_tests/unit_areas/ParallaxContainerTest.php
+++ b/tests/bundle_tests/unit_areas/ParallaxContainerTest.php
@@ -10,6 +10,29 @@ use ToolboxBundle\Model\Document\Tag\ParallaxImage;
 
 class ParallaxContainerTest extends AbstractAreaTest
 {
+    public function testParallaxContainerConfigParameter()
+    {
+        $configParam = $this->getToolboxConfig()->getAreaParameterConfig('parallaxContainer');
+        $this->assertEquals(
+            [
+                'window_size'           => 'large',
+                'background_mode'       => 'wrap',
+                'background_image_mode' => 'data',
+                'background_color_mode' => 'data'
+            ],
+            $configParam
+        );
+
+        $configParam = $this->getToolboxConfig()->getAreaParameterConfig('parallaxContainerSection');
+        $this->assertEquals(
+            [
+                'background_image_mode' => 'data',
+                'background_color_mode' => 'data'
+            ],
+            $configParam
+        );
+    }
+
     private function getDefaultElements($asset)
     {
         $backgroundImage = new Href();

--- a/tests/bundle_tests/unit_areas/SeparatorTest.php
+++ b/tests/bundle_tests/unit_areas/SeparatorTest.php
@@ -6,6 +6,20 @@ use Pimcore\Model\Document\Tag\Select;
 
 class SeparatorTest extends AbstractAreaTest
 {
+    const TYPE = 'separator';
+
+    public function testSeparatorBackendConfig()
+    {
+        $this->setupRequest();
+
+        $areaConfig = $this->generateBackendArea(self::TYPE);
+        $configElements = $areaConfig['config_elements'];
+
+        $this->assertCount(1, $configElements);
+        $this->assertEquals('select', $configElements[0]['additional_config']['type']);
+        $this->assertEquals('space', $configElements[0]['additional_config']['name']);
+    }
+
     public function testSeparator()
     {
         $this->setupRequest();
@@ -19,7 +33,7 @@ class SeparatorTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompare()),
-            $this->filter($this->generateRenderedArea('separator', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -40,7 +54,7 @@ class SeparatorTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithAdditionalClass()),
-            $this->filter($this->generateRenderedArea('separator', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 

--- a/tests/bundle_tests/unit_areas/SeparatorTest.php
+++ b/tests/bundle_tests/unit_areas/SeparatorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace DachcomBundle\Test\Unit;
+
+use Pimcore\Model\Document\Tag\Select;
+
+class SeparatorTest extends AbstractAreaTest
+{
+    public function testSeparator()
+    {
+        $this->setupRequest();
+
+        $space = new Select();
+        $space->setDataFromEditmode('large');
+
+        $elements = [
+            'space' => $space
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompare()),
+            $this->filter($this->generateRenderedArea('separator', $elements))
+        );
+    }
+
+    public function testSeperatorWithAdditionalClass()
+    {
+        $this->setupRequest();
+
+        $space = new Select();
+        $space->setDataFromEditmode('large');
+
+        $combo = new Select();
+        $combo->setDataFromResource('additional-class');
+
+        $elements = [
+            'space'       => $space,
+            'add_classes' => $combo
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithAdditionalClass()),
+            $this->filter($this->generateRenderedArea('separator', $elements))
+        );
+    }
+
+    private function getCompare()
+    {
+        return '<div class="toolbox-element toolbox-separator "><hr class="large"></div>';
+    }
+
+    private function getCompareWithAdditionalClass()
+    {
+        return '<div class="toolbox-element toolbox-separator additional-class"><hr class="large"></div>';
+    }
+}

--- a/tests/bundle_tests/unit_areas/SlideColumnsTest.php
+++ b/tests/bundle_tests/unit_areas/SlideColumnsTest.php
@@ -7,6 +7,23 @@ use Pimcore\Model\Document\Tag\Select;
 
 class SlideColumnsTest extends AbstractAreaTest
 {
+    const TYPE = 'slideColumns';
+
+    public function testSlideColumnsBackendConfig()
+    {
+        $this->setupRequest();
+
+        $areaConfig = $this->generateBackendArea(self::TYPE);
+        $configElements = $areaConfig['config_elements'];
+
+        $this->assertCount(2, $configElements);
+        $this->assertEquals('select', $configElements[0]['additional_config']['type']);
+        $this->assertEquals('slides_per_view', $configElements[0]['additional_config']['name']);
+
+        $this->assertEquals('checkbox', $configElements[1]['additional_config']['type']);
+        $this->assertEquals('equal_height', $configElements[1]['additional_config']['name']);
+    }
+
     public function testSlideColumnsConfigParameter()
     {
         $configParam = $this->getToolboxConfig()->getAreaParameterConfig('slideColumns');
@@ -34,7 +51,7 @@ class SlideColumnsTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompare()),
-            $this->filter($this->generateRenderedArea('slideColumns', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -55,7 +72,7 @@ class SlideColumnsTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithEqualHeight()),
-            $this->filter($this->generateRenderedArea('slideColumns', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -71,7 +88,7 @@ class SlideColumnsTest extends AbstractAreaTest
 
         $configManager = $this->getToolboxConfig();
 
-        $slideColumns = $configManager->getConfig('slideColumns');
+        $slideColumns = $configManager->getConfig(self::TYPE);
         $theme = $configManager->getConfig('theme');
 
         $slideColumns['config_parameter'] = [
@@ -83,7 +100,7 @@ class SlideColumnsTest extends AbstractAreaTest
             ]
         ];
 
-        $configManager->setConfig(['areas' => ['slideColumns' => $slideColumns], 'theme' => $theme]);
+        $configManager->setConfig(['areas' => [self::TYPE => $slideColumns], 'theme' => $theme]);
 
         $elements = [
             'slides_per_view' => $slidesPerView,
@@ -92,7 +109,7 @@ class SlideColumnsTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithBreakPoints()),
-            $this->filter($this->generateRenderedArea('slideColumns', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -113,7 +130,7 @@ class SlideColumnsTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithAdditionalClass()),
-            $this->filter($this->generateRenderedArea('slideColumns', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 

--- a/tests/bundle_tests/unit_areas/SlideColumnsTest.php
+++ b/tests/bundle_tests/unit_areas/SlideColumnsTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace DachcomBundle\Test\Unit;
+
+use Pimcore\Model\Document\Tag\Checkbox;
+use Pimcore\Model\Document\Tag\Select;
+use ToolboxBundle\Manager\ConfigManager;
+
+class SlideColumnsTest extends AbstractAreaTest
+{
+    public function testSlideColumns()
+    {
+        $this->setupRequest();
+
+        $slidesPerView = new Select();
+        $slidesPerView->setDataFromResource('4');
+
+        $elements = [
+            'slides_per_view' => $slidesPerView
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompare()),
+            $this->filter($this->generateRenderedArea('slideColumns', $elements))
+        );
+    }
+
+    public function testSlideColumnsWithEqualHeight()
+    {
+        $this->setupRequest();
+
+        $slidesPerView = new Select();
+        $slidesPerView->setDataFromResource('4');
+
+        $equalHeight = new Checkbox();
+        $equalHeight->setDataFromEditmode(1);
+
+        $elements = [
+            'slides_per_view' => $slidesPerView,
+            'equal_height'    => $equalHeight
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithEqualHeight()),
+            $this->filter($this->generateRenderedArea('slideColumns', $elements))
+        );
+    }
+
+    public function testSlideColumnsWithBreakPoints()
+    {
+        $this->setupRequest();
+
+        $slidesPerView = new Select();
+        $slidesPerView->setDataFromResource('4');
+
+        $equalHeight = new Checkbox();
+        $equalHeight->setDataFromEditmode(1);
+
+        $configManager = $this->getContainer()->get(ConfigManager::class);
+
+        $slideColumns = $configManager->getConfig('slideColumns');
+        $theme = $configManager->getConfig('theme');
+
+        $slideColumns['config_parameter'] = [
+            'column_classes' => [
+                4 => 'col-12 col-sm-12 col-lg-2',
+            ],
+            'breakpoints' => [
+                4 => 'col-12 col-sm-12 col-lg-2'
+            ]
+        ];
+
+        $configManager->setConfig(['areas' => ['slideColumns' => $slideColumns], 'theme' => $theme]);
+
+        $elements = [
+            'slides_per_view' => $slidesPerView,
+            'equal_height'    => $equalHeight
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithBreakPoints()),
+            $this->filter($this->generateRenderedArea('slideColumns', $elements))
+        );
+    }
+
+    public function testSlideColumnsWithAdditionalClass()
+    {
+        $this->setupRequest();
+
+        $combo = new Select();
+        $combo->setDataFromResource('additional-class');
+
+        $slidesPerView = new Select();
+        $slidesPerView->setDataFromResource('4');
+
+        $elements = [
+            'slides_per_view' => $slidesPerView,
+            'add_classes'     => $combo
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithAdditionalClass()),
+            $this->filter($this->generateRenderedArea('slideColumns', $elements))
+        );
+    }
+
+    private function getCompare()
+    {
+        return '<div class="toolbox-element toolbox-slide-columns  ">
+                    <div class="row">
+                        <div class="slide-columns slide-elements-4 slideColumns-1" data-slides="4" data-breakpoints="[]">
+                            <div class="column col-12 col-sm-3">
+                                <div class="slide-column slide-1"></div>
+                            </div>
+                            <div class="column col-12 col-sm-3">
+                                <div class="slide-column slide-2"></div>
+                            </div>
+                            <div class="column col-12 col-sm-3">
+                                <div class="slide-column slide-3"></div>
+                            </div>
+                            <div class="column col-12 col-sm-3">
+                                <div class="slide-column slide-4"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareWithEqualHeight()
+    {
+        return '<div class="toolbox-element toolbox-slide-columns  equal-height">
+                    <div class="row">
+                        <div class="slide-columns slide-elements-4 slideColumns-1" data-slides="4" data-breakpoints="[]">
+                            <div class="column col-12 col-sm-3">
+                                <div class="slide-column slide-1"></div>
+                            </div>
+                            <div class="column col-12 col-sm-3">
+                                <div class="slide-column slide-2"></div>
+                            </div>
+                            <div class="column col-12 col-sm-3">
+                                <div class="slide-column slide-3"></div>
+                            </div>
+                            <div class="column col-12 col-sm-3">
+                                <div class="slide-column slide-4"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareWithBreakPoints()
+    {
+        return '<div class="toolbox-element toolbox-slide-columns  equal-height">
+                    <div class="row">
+                        <div class="slide-columns slide-elements-4 slideColumns-1" data-slides="4" data-breakpoints="&quot;col-12 col-sm-12 col-lg-2&quot;">
+                            <div class="column col-12 col-sm-12 col-lg-2">
+                                <div class="slide-column slide-1"></div>
+                            </div>
+                            <div class="column col-12 col-sm-12 col-lg-2">
+                                <div class="slide-column slide-2"></div>
+                            </div>
+                            <div class="column col-12 col-sm-12 col-lg-2">
+                                <div class="slide-column slide-3"></div>
+                            </div>
+                            <div class="column col-12 col-sm-12 col-lg-2">
+                                <div class="slide-column slide-4"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareWithAdditionalClass()
+    {
+        return '<div class="toolbox-element toolbox-slide-columns additional-class ">
+                    <div class="row">
+                        <div class="slide-columns slide-elements-4 slideColumns-1" data-slides="4" data-breakpoints="[]">
+                            <div class="column col-12 col-sm-3">
+                                <div class="slide-column slide-1"></div>
+                            </div>
+                            <div class="column col-12 col-sm-3">
+                                <div class="slide-column slide-2"></div>
+                            </div>
+                            <div class="column col-12 col-sm-3">
+                                <div class="slide-column slide-3"></div>
+                            </div>
+                            <div class="column col-12 col-sm-3">
+                                <div class="slide-column slide-4"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>';
+    }
+}

--- a/tests/bundle_tests/unit_areas/SlideColumnsTest.php
+++ b/tests/bundle_tests/unit_areas/SlideColumnsTest.php
@@ -4,10 +4,23 @@ namespace DachcomBundle\Test\Unit;
 
 use Pimcore\Model\Document\Tag\Checkbox;
 use Pimcore\Model\Document\Tag\Select;
-use ToolboxBundle\Manager\ConfigManager;
 
 class SlideColumnsTest extends AbstractAreaTest
 {
+    public function testSlideColumnsConfigParameter()
+    {
+        $configParam = $this->getToolboxConfig()->getAreaParameterConfig('slideColumns');
+        $this->assertEquals(
+            [
+                'column_classes' => [
+                    '2' => 'col-12 col-sm-6'
+                ],
+                'breakpoints'    => []
+            ],
+            $configParam
+        );
+    }
+
     public function testSlideColumns()
     {
         $this->setupRequest();
@@ -56,7 +69,7 @@ class SlideColumnsTest extends AbstractAreaTest
         $equalHeight = new Checkbox();
         $equalHeight->setDataFromEditmode(1);
 
-        $configManager = $this->getContainer()->get(ConfigManager::class);
+        $configManager = $this->getToolboxConfig();
 
         $slideColumns = $configManager->getConfig('slideColumns');
         $theme = $configManager->getConfig('theme');
@@ -65,7 +78,7 @@ class SlideColumnsTest extends AbstractAreaTest
             'column_classes' => [
                 4 => 'col-12 col-sm-12 col-lg-2',
             ],
-            'breakpoints' => [
+            'breakpoints'    => [
                 4 => 'col-12 col-sm-12 col-lg-2'
             ]
         ];

--- a/tests/bundle_tests/unit_areas/SpacerTest.php
+++ b/tests/bundle_tests/unit_areas/SpacerTest.php
@@ -6,6 +6,20 @@ use Pimcore\Model\Document\Tag\Select;
 
 class SpacerTest extends AbstractAreaTest
 {
+    const TYPE = 'spacer';
+
+    public function testSpacerBackendConfig()
+    {
+        $this->setupRequest();
+
+        $areaConfig = $this->generateBackendArea(self::TYPE);
+        $configElements = $areaConfig['config_elements'];
+
+        $this->assertCount(1, $configElements);
+        $this->assertEquals('select', $configElements[0]['additional_config']['type']);
+        $this->assertEquals('spacer_class', $configElements[0]['additional_config']['name']);
+    }
+
     public function testSpacer()
     {
         $this->setupRequest();
@@ -19,7 +33,7 @@ class SpacerTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompare()),
-            $this->filter($this->generateRenderedArea('spacer', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -40,7 +54,7 @@ class SpacerTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithAdditionalClass()),
-            $this->filter($this->generateRenderedArea('spacer', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 

--- a/tests/bundle_tests/unit_areas/SpacerTest.php
+++ b/tests/bundle_tests/unit_areas/SpacerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace DachcomBundle\Test\Unit;
+
+use Pimcore\Model\Document\Tag\Select;
+
+class SpacerTest extends AbstractAreaTest
+{
+    public function testSpacer()
+    {
+        $this->setupRequest();
+
+        $spacerClass = new Select();
+        $spacerClass->setDataFromEditmode('spacer-50');
+
+        $elements = [
+            'spacer_class' => $spacerClass
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompare()),
+            $this->filter($this->generateRenderedArea('spacer', $elements))
+        );
+    }
+
+     public function testSpacerWithAdditionalClass()
+    {
+        $this->setupRequest();
+
+        $combo = new Select();
+        $combo->setDataFromResource('additional-class');
+
+        $spacerClass = new Select();
+        $spacerClass->setDataFromEditmode('spacer-50');
+
+        $elements = [
+            'add_classes' => $combo,
+            'spacer_class' => $spacerClass
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithAdditionalClass()),
+            $this->filter($this->generateRenderedArea('spacer', $elements))
+        );
+    }
+
+    private function getCompare()
+    {
+        return '<div class="toolbox-element toolbox-spacer " ><span class="spacer-50"></span></div>';
+    }
+
+    private function getCompareWithAdditionalClass()
+    {
+        return '<div class="toolbox-element toolbox-spacer additional-class" ><span class="spacer-50"></span></div>';
+    }
+}

--- a/tests/bundle_tests/unit_areas/TeaserTest.php
+++ b/tests/bundle_tests/unit_areas/TeaserTest.php
@@ -12,6 +12,75 @@ use Pimcore\Tests\Util\TestHelper;
 
 class TeaserTest extends AbstractAreaTest
 {
+    const TYPE = 'teaser';
+
+    public function testTeaserBackendConfig()
+    {
+        $this->setupRequest();
+
+        $areaConfig = $this->generateBackendArea(self::TYPE);
+        $configElements = $areaConfig['config_elements'];
+
+        $this->assertCount(3, $configElements);
+        $this->assertEquals('select', $configElements[0]['additional_config']['type']);
+        $this->assertEquals('type', $configElements[0]['additional_config']['name']);
+
+        $this->assertEquals('select', $configElements[1]['additional_config']['type']);
+        $this->assertEquals('layout', $configElements[1]['additional_config']['name']);
+
+        $this->assertEquals('checkbox', $configElements[2]['additional_config']['type']);
+        $this->assertEquals('use_light_box', $configElements[2]['additional_config']['name']);
+    }
+
+    public function testTeaser()
+    {
+        $this->setupRequest();
+
+        $asset = TestHelper::createImageAsset('', true);
+        $elements = $this->getDefaultElements($asset);
+
+        $this->assertEquals(
+            $this->filter($this->getCompare($asset->getFullPath())),
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
+        );
+    }
+
+    public function testTeaserWithLightBox()
+    {
+        $this->setupRequest();
+
+        $asset = TestHelper::createImageAsset('', true);
+        $elements = $this->getDefaultElements($asset);
+
+        $lightBox = new Checkbox();
+        $lightBox->setDataFromEditmode(1);
+
+        $elements['use_light_box'] = $lightBox;
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithLightBox($asset->getFullPath())),
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
+        );
+    }
+
+    public function testTeaserWithAdditionalClass()
+    {
+        $this->setupRequest();
+
+        $asset = TestHelper::createImageAsset('', true);
+        $elements = $this->getDefaultElements($asset);
+
+        $combo = new Select();
+        $combo->setDataFromResource('additional-class');
+
+        $elements['add_classes'] = $combo;
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithAdditionalClass($asset->getFullPath())),
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
+        );
+    }
+
     private function getDefaultElements($asset)
     {
         $type = new Select();
@@ -43,55 +112,6 @@ class TeaserTest extends AbstractAreaTest
             'text'     => $text,
             'headline' => $headline
         ];
-    }
-
-    public function testTeaser()
-    {
-        $this->setupRequest();
-
-        $asset = TestHelper::createImageAsset('', true);
-        $elements = $this->getDefaultElements($asset);
-
-        $this->assertEquals(
-            $this->filter($this->getCompare($asset->getFullPath())),
-            $this->filter($this->generateRenderedArea('teaser', $elements))
-        );
-    }
-
-    public function testTeaserWithLightBox()
-    {
-        $this->setupRequest();
-
-        $asset = TestHelper::createImageAsset('', true);
-        $elements = $this->getDefaultElements($asset);
-
-        $lightBox = new Checkbox();
-        $lightBox->setDataFromEditmode(1);
-
-        $elements['use_light_box'] = $lightBox;
-
-        $this->assertEquals(
-            $this->filter($this->getCompareWithLightBox($asset->getFullPath())),
-            $this->filter($this->generateRenderedArea('teaser', $elements))
-        );
-    }
-
-    public function testTeaserWithAdditionalClass()
-    {
-        $this->setupRequest();
-
-        $asset = TestHelper::createImageAsset('', true);
-        $elements = $this->getDefaultElements($asset);
-
-        $combo = new Select();
-        $combo->setDataFromResource('additional-class');
-
-        $elements['add_classes'] = $combo;
-
-        $this->assertEquals(
-            $this->filter($this->getCompareWithAdditionalClass($asset->getFullPath())),
-            $this->filter($this->generateRenderedArea('teaser', $elements))
-        );
     }
 
     private function getCompare($asset)

--- a/tests/bundle_tests/unit_areas/TeaserTest.php
+++ b/tests/bundle_tests/unit_areas/TeaserTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace DachcomBundle\Test\Unit;
+
+use Pimcore\Model\Document\Tag\Checkbox;
+use Pimcore\Model\Document\Tag\Image;
+use Pimcore\Model\Document\Tag\Input;
+use Pimcore\Model\Document\Tag\Link;
+use Pimcore\Model\Document\Tag\Select;
+use Pimcore\Model\Document\Tag\Wysiwyg;
+use Pimcore\Tests\Util\TestHelper;
+
+class TeaserTest extends AbstractAreaTest
+{
+    private function getDefaultElements($asset)
+    {
+        $type = new Select();
+        $type->setDataFromResource('direct');
+
+        $layout = new Select();
+        $layout->setDataFromResource('default');
+
+        $link = new Link();
+        $link->setDataFromResource(['path' => '/test/test2']);
+
+        $image = new Image();
+        $image->setDataFromEditmode([
+            'id'  => $asset->getId(),
+            'alt' => 'alt text'
+        ]);
+
+        $text = new Wysiwyg();
+        $text->setDataFromEditmode('teaser text');
+
+        $headline = new Input();
+        $headline->setDataFromEditmode('teaser headline');
+
+        return [
+            'type'     => $type,
+            'layout'   => $layout,
+            'link'     => $link,
+            'image'    => $image,
+            'text'     => $text,
+            'headline' => $headline
+        ];
+    }
+
+    public function testTeaser()
+    {
+        $this->setupRequest();
+
+        $asset = TestHelper::createImageAsset('', true);
+        $elements = $this->getDefaultElements($asset);
+
+        $this->assertEquals(
+            $this->filter($this->getCompare($asset->getFullPath())),
+            $this->filter($this->generateRenderedArea('teaser', $elements))
+        );
+    }
+
+    public function testTeaserWithLightBox()
+    {
+        $this->setupRequest();
+
+        $asset = TestHelper::createImageAsset('', true);
+        $elements = $this->getDefaultElements($asset);
+
+        $lightBox = new Checkbox();
+        $lightBox->setDataFromEditmode(1);
+
+        $elements['use_light_box'] = $lightBox;
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithLightBox($asset->getFullPath())),
+            $this->filter($this->generateRenderedArea('teaser', $elements))
+        );
+    }
+
+    public function testTeaserWithAdditionalClass()
+    {
+        $this->setupRequest();
+
+        $asset = TestHelper::createImageAsset('', true);
+        $elements = $this->getDefaultElements($asset);
+
+        $combo = new Select();
+        $combo->setDataFromResource('additional-class');
+
+        $elements['add_classes'] = $combo;
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithAdditionalClass($asset->getFullPath())),
+            $this->filter($this->generateRenderedArea('teaser', $elements))
+        );
+    }
+
+    private function getCompare($asset)
+    {
+        return '<div class="toolbox-element toolbox-teaser ">
+                    <div class="row">
+                        <div class="col-12">
+                            <div class="single-teaser default ">
+                                <a href="/test/test2"  class="item">
+                                    <img class="img-responsive" alt="alt text" title="alt text" src="' . $asset . '" />
+                                </a>
+                                <h3 class="teaser-headline">teaser headline</h3>
+                                <div class="teaser-text">        teaser text    </div>
+                                <a href="/test/test2" class="btn btn-default teaser-link"></a>
+                            </div>
+                        </div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareWithLightBox($asset)
+    {
+        return '<div class="toolbox-element toolbox-teaser ">
+                    <div class="row">
+                        <div class="col-12">
+                            <div class="single-teaser default light-box">
+                                <a href="' . $asset . '" class="item">
+                                    <img class="img-responsive" alt="alt text" title="alt text" src="' . $asset . '" />
+                                </a>
+                                <h3 class="teaser-headline">teaser headline</h3><div class="teaser-text">        teaser text    </div>
+                                <a href="/test/test2" class="btn btn-default teaser-link"></a>
+                            </div>
+                        </div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareWithAdditionalClass($asset)
+    {
+        return '<div class="toolbox-element toolbox-teaser additional-class">
+                    <div class="row">
+                        <div class="col-12">
+                            <div class="single-teaser default ">
+                                <a href="/test/test2"  class="item">
+                                    <img class="img-responsive" alt="alt text" title="alt text" src="' . $asset . '" />
+                                </a>
+                                <h3 class="teaser-headline">teaser headline</h3>
+                                <div class="teaser-text">        teaser text    </div>
+                                <a href="/test/test2" class="btn btn-default teaser-link"></a>
+                            </div>
+                        </div>
+                    </div>
+                </div>';
+    }
+}

--- a/tests/bundle_tests/unit_areas/VideoTest.php
+++ b/tests/bundle_tests/unit_areas/VideoTest.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace DachcomBundle\Test\Unit;
+
+use Pimcore\Model\Document\Tag\Checkbox;
+use Pimcore\Model\Document\Tag\Select;
+use Pimcore\Tests\Util\TestHelper;
+use ToolboxBundle\Model\Document\Tag\Vhs;
+
+class VideoTest extends AbstractAreaTest
+{
+    public function testYoutubeVideo()
+    {
+        $this->setupRequest();
+
+        $asset = TestHelper::createImageAsset('', true);
+
+        $video = new Vhs();
+        $video->setDataFromEditmode([
+            'type'   => 'youtube',
+            'path'   => 'https://www.youtube.com/watch?v=EhhGzxhtx48',
+            'poster' => $asset->getFullPath()
+        ]);
+
+        $elements = [
+            'video' => $video
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompare($asset->getFullPath())),
+            $this->filter($this->generateRenderedArea('video', $elements))
+        );
+    }
+
+    public function testVimeoVideo()
+    {
+        $this->setupRequest();
+
+        $asset = TestHelper::createImageAsset('', true);
+
+        $video = new Vhs();
+        $video->setDataFromEditmode([
+            'type'   => 'vimeo',
+            'path'   => 'https://vimeo.com/76979871',
+            'poster' => $asset->getFullPath()
+        ]);
+
+        $elements = [
+            'video' => $video
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareVimeo($asset->getFullPath())),
+            $this->filter($this->generateRenderedArea('video', $elements))
+        );
+    }
+    public function testAssetVideo()
+    {
+        $this->setupRequest();
+
+        $asset = TestHelper::createImageAsset('', true);
+
+        $video = new Vhs();
+        $video->setDataFromEditmode([
+            'type'   => 'asset',
+            'path'   => $asset->getFullPath(),
+            'poster' => $asset->getFullPath()
+        ]);
+
+        $elements = [
+            'video' => $video
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareAsset($asset->getFullPath())),
+            $this->filter($this->generateRenderedArea('video', $elements))
+        );
+    }
+
+    public function testVideoWithLightBox()
+    {
+        $this->setupRequest();
+
+        $asset = TestHelper::createImageAsset('', true);
+
+        $video = new Vhs();
+        $video->setDataFromEditmode([
+            'type'           => 'youtube',
+            'path'           => 'https://www.youtube.com/watch?v=EhhGzxhtx48',
+            'poster'         => $asset->getFullPath(),
+            'showAsLightbox' => true
+        ]);
+
+        $elements = [
+            'video' => $video
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithLightBox($asset->getFullPath())),
+            $this->filter($this->generateRenderedArea('video', $elements))
+        );
+    }
+
+    public function testVideoWithAutoplay()
+    {
+        $this->setupRequest();
+
+        $asset = TestHelper::createImageAsset('', true);
+
+        $video = new Vhs();
+        $video->setDataFromEditmode([
+            'type'           => 'youtube',
+            'path'           => 'https://www.youtube.com/watch?v=EhhGzxhtx48',
+            'poster'         => $asset->getFullPath(),
+            'showAsLightbox' => true
+        ]);
+
+        $autoplay = new Checkbox();
+        $autoplay->setDataFromEditmode(1);
+
+        $elements = [
+            'video'    => $video,
+            'autoplay' => $autoplay
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithAutoplay($asset->getFullPath())),
+            $this->filter($this->generateRenderedArea('video', $elements))
+        );
+    }
+
+    public function testVideoWithAdditionalClass()
+    {
+        $this->setupRequest();
+
+        $combo = new Select();
+        $combo->setDataFromResource('additional-class');
+
+        $asset = TestHelper::createImageAsset('', true);
+
+        $video = new Vhs();
+        $video->setDataFromEditmode([
+            'type'   => 'youtube',
+            'id'     => 'https://www.youtube.com/watch?v=EhhGzxhtx48',
+            'poster' => $asset->getFullPath()
+        ]);
+
+        $elements = [
+            'video'       => $video,
+            'add_classes' => $combo
+        ];
+
+        $this->assertEquals(
+            $this->filter($this->getCompareWithAdditionalClass($asset->getFullPath())),
+            $this->filter($this->generateRenderedArea('video', $elements))
+        );
+    }
+
+    private function getCompare($path)
+    {
+        return '<div class="toolbox-element toolbox-video  " data-type="youtube">
+                    <div class="video-inner">
+                        <div class="player" data-poster-path="' . $path . '" data-play-in-lightbox="false" data-video-uri="https://www.youtube.com/watch?v=EhhGzxhtx48"></div>
+                        <div class="poster-overlay lightbox" style="background-image:url(\'' . $path . '\');">
+                            <span class="icon"></span>
+                        </div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareVimeo($path)
+    {
+        return '<div class="toolbox-element toolbox-video  " data-type="vimeo">
+                    <div class="video-inner">
+                        <div class="player" data-poster-path="' . $path . '" data-play-in-lightbox="false" data-video-uri="https://vimeo.com/76979871"></div>
+                        <div class="poster-overlay lightbox" style="background-image:url(\'' . $path . '\');">
+                            <span class="icon"></span>
+                        </div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareAsset($path)
+    {
+        return '<div class="toolbox-element toolbox-video  " data-type="asset">
+                    <div class="video-inner">
+                        <div class="player" data-poster-path="' . $path . '" data-play-in-lightbox="false" data-video-uri="' . $path . '"></div>
+                        <div id="pimcore_video_" class="pimcore_tag_video">
+                            <div class="pimcore_tag_video_error" style="text-align:center; width: 100%; height: 249px; border:1px solid #000; background: url(/bundles/pimcoreadmin/img/filetype-not-supported.svg) no-repeat center center #fff;">                Asset is not a video, or missing thumbnail configuration            </div>
+                        </div>
+                    </div>
+                    <div class="poster-overlay lightbox" style="background-image:url(\'' . $path . '\');">
+                        <span class="icon"></span>
+                    </div>
+                </div>
+            </div>';
+    }
+
+    private function getCompareWithLightBox($path)
+    {
+        return '<div class="toolbox-element toolbox-video  " data-type="youtube">
+                    <div class="video-inner">
+                        <div class="player" data-poster-path="' . $path . '" data-play-in-lightbox="true" data-video-uri="https://www.youtube.com/watch?v=EhhGzxhtx48"></div>
+                        <div class="poster-overlay lightbox" style="background-image:url(\'' . $path . '\');">
+                            <span class="icon"></span>
+                        </div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareWithAutoplay($path)
+    {
+        return '<div class="toolbox-element toolbox-video   autoplay" data-type="youtube">
+                    <div class="video-inner">
+                        <div class="player" data-poster-path="' . $path . '" data-play-in-lightbox="true" data-video-uri="https://www.youtube.com/watch?v=EhhGzxhtx48"></div>
+                        <div class="poster-overlay lightbox" style="background-image:url(\'' . $path . '\');">
+                            <span class="icon"></span>
+                        </div>
+                    </div>
+                </div>';
+    }
+
+    private function getCompareWithAdditionalClass($path)
+    {
+        return '<div class="toolbox-element toolbox-video additional-class " data-type="youtube">
+                    <div class="video-inner">
+                        <div class="player" data-poster-path="' . $path . '" data-play-in-lightbox="false" data-video-uri="https://www.youtube.com/watch?v=EhhGzxhtx48"></div>
+                        <div class="poster-overlay lightbox" style="background-image:url(\'' . $path . '\');">
+                            <span class="icon"></span>
+                        </div>
+                    </div>
+                </div>';
+    }
+}

--- a/tests/bundle_tests/unit_areas/VideoTest.php
+++ b/tests/bundle_tests/unit_areas/VideoTest.php
@@ -54,29 +54,7 @@ class VideoTest extends AbstractAreaTest
             $this->filter($this->generateRenderedArea('video', $elements))
         );
     }
-    public function testAssetVideo()
-    {
-        $this->setupRequest();
-
-        $asset = TestHelper::createImageAsset('', true);
-
-        $video = new Vhs();
-        $video->setDataFromEditmode([
-            'type'   => 'asset',
-            'path'   => $asset->getFullPath(),
-            'poster' => $asset->getFullPath()
-        ]);
-
-        $elements = [
-            'video' => $video
-        ];
-
-        $this->assertEquals(
-            $this->filter($this->getCompareAsset($asset->getFullPath())),
-            $this->filter($this->generateRenderedArea('video', $elements))
-        );
-    }
-
+    
     public function testVideoWithLightBox()
     {
         $this->setupRequest();
@@ -178,22 +156,6 @@ class VideoTest extends AbstractAreaTest
                         </div>
                     </div>
                 </div>';
-    }
-
-    private function getCompareAsset($path)
-    {
-        return '<div class="toolbox-element toolbox-video  " data-type="asset">
-                    <div class="video-inner">
-                        <div class="player" data-poster-path="' . $path . '" data-play-in-lightbox="false" data-video-uri="' . $path . '"></div>
-                        <div id="pimcore_video_" class="pimcore_tag_video">
-                            <div class="pimcore_tag_video_error" style="text-align:center; width: 100%; height: 249px; border:1px solid #000; background: url(/bundles/pimcoreadmin/img/filetype-not-supported.svg) no-repeat center center #fff;">                Asset is not a video, or missing thumbnail configuration            </div>
-                        </div>
-                    </div>
-                    <div class="poster-overlay lightbox" style="background-image:url(\'' . $path . '\');">
-                        <span class="icon"></span>
-                    </div>
-                </div>
-            </div>';
     }
 
     private function getCompareWithLightBox($path)

--- a/tests/bundle_tests/unit_areas/VideoTest.php
+++ b/tests/bundle_tests/unit_areas/VideoTest.php
@@ -9,6 +9,34 @@ use ToolboxBundle\Model\Document\Tag\Vhs;
 
 class VideoTest extends AbstractAreaTest
 {
+    public function testVideoConfigParameter()
+    {
+        $configParam = $this->getToolboxConfig()->getAreaParameterConfig('video');
+        $this->assertEquals(
+            [
+                'video_types' => [
+                    'asset' => [
+                        'active'         => false,
+                        'allow_lightbox' => true
+                    ],
+                    'youtube' => [
+                        'active'         => true,
+                        'allow_lightbox' => true
+                    ],
+                    'vimeo' => [
+                        'active'         => false,
+                        'allow_lightbox' => true
+                    ],
+                    'dailymotion' => [
+                        'active'         => false,
+                        'allow_lightbox' => true
+                    ]
+                ]
+            ],
+            $configParam
+        );
+    }
+
     public function testYoutubeVideo()
     {
         $this->setupRequest();
@@ -54,7 +82,7 @@ class VideoTest extends AbstractAreaTest
             $this->filter($this->generateRenderedArea('video', $elements))
         );
     }
-    
+
     public function testVideoWithLightBox()
     {
         $this->setupRequest();

--- a/tests/bundle_tests/unit_areas/VideoTest.php
+++ b/tests/bundle_tests/unit_areas/VideoTest.php
@@ -9,21 +9,35 @@ use ToolboxBundle\Model\Document\Tag\Vhs;
 
 class VideoTest extends AbstractAreaTest
 {
+    const TYPE = 'video';
+
+    public function testVideoBackendConfig()
+    {
+        $this->setupRequest();
+
+        $areaConfig = $this->generateBackendArea(self::TYPE);
+        $configElements = $areaConfig['config_elements'];
+
+        $this->assertCount(1, $configElements);
+        $this->assertEquals('checkbox', $configElements[0]['additional_config']['type']);
+        $this->assertEquals('autoplay', $configElements[0]['additional_config']['name']);
+    }
+
     public function testVideoConfigParameter()
     {
         $configParam = $this->getToolboxConfig()->getAreaParameterConfig('video');
         $this->assertEquals(
             [
                 'video_types' => [
-                    'asset' => [
+                    'asset'       => [
                         'active'         => false,
                         'allow_lightbox' => true
                     ],
-                    'youtube' => [
+                    'youtube'     => [
                         'active'         => true,
                         'allow_lightbox' => true
                     ],
-                    'vimeo' => [
+                    'vimeo'       => [
                         'active'         => false,
                         'allow_lightbox' => true
                     ],
@@ -56,7 +70,7 @@ class VideoTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompare($asset->getFullPath())),
-            $this->filter($this->generateRenderedArea('video', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -79,7 +93,7 @@ class VideoTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareVimeo($asset->getFullPath())),
-            $this->filter($this->generateRenderedArea('video', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -103,7 +117,7 @@ class VideoTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithLightBox($asset->getFullPath())),
-            $this->filter($this->generateRenderedArea('video', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -131,7 +145,7 @@ class VideoTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithAutoplay($asset->getFullPath())),
-            $this->filter($this->generateRenderedArea('video', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 
@@ -158,7 +172,7 @@ class VideoTest extends AbstractAreaTest
 
         $this->assertEquals(
             $this->filter($this->getCompareWithAdditionalClass($asset->getFullPath())),
-            $this->filter($this->generateRenderedArea('video', $elements))
+            $this->filter($this->generateRenderedArea(self::TYPE, $elements))
         );
     }
 

--- a/tests/bundle_tests/unit_areas/_bootstrap.php
+++ b/tests/bundle_tests/unit_areas/_bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+// Here you can initialize variables that will be available to your tests

--- a/tests/etc/config/bundle/symfony/config_default.yml
+++ b/tests/etc/config/bundle/symfony/config_default.yml
@@ -1,0 +1,21 @@
+toolbox:
+    theme:
+        grid:
+            grid_size: 12
+            breakpoints:
+                -
+                    identifier: 'xs'
+                    name: 'Breakpoint: XS'
+                    description: 'Your Description'
+                -
+                    identifier: 'sm'
+                    name: 'Breakpoint: SM'
+                    description: 'Your Description'
+                -
+                    identifier: 'md'
+                    name: 'Breakpoint: MD'
+                    description: 'Your Description'
+                -
+                    identifier: 'lg'
+                    name: 'Breakpoint: LG'
+                    description: 'Your Description'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Create tests for each rendered area element.
Also:
-> skip config element with empty store
-> use `view->getParameters()->add(['foo' => 'bar'])` instead of `$view->foo = bar`.