### PR TITLE
fixes issue #86

### DIFF
--- a/docs/11_ElementsOverview.md
+++ b/docs/11_ElementsOverview.md
@@ -220,6 +220,7 @@ toolbox:
                 map_style_url: false
                 marker_icon: false
                 map_api_key: false
+                simple_api_key: false
 ```
 ### jQuery Plugin
 There is also a jquery plugin for the google maps element. Read more about it [here](80_Javascript.md#google-maps-extension)

--- a/docs/11_ElementsOverview.md
+++ b/docs/11_ElementsOverview.md
@@ -203,7 +203,8 @@ Please make sure that you've included a valid google maps api key. Include the s
 | `map_options` | array | Map Zoom | [] |
 | `map_style_url` | string | Define a custom map style (path to json) | false |
 | `marker_icon` | string | Define a custom marker_icon (path to icon) | false |
-| `map_api_key` | string | Set a custom map api key. To extend the daily request to 2.500 per day. This parameter tries to load the browser api key from the system settings! | `'%pimcore_system_config.services.google.browserapikey%'` |
+| `map_api_key` | string | Set a custom map api key. To extend the daily request to 2.500 per day. This parameter tries to load the browser api key from the system settings! This key is used by frontend-api-requests | `'%pimcore_system_config.services.google.browserapikey%'` |
+| `simple_api_key` | string | Set a custom simple api key. To extend the daily request to 2.500 per day. This parameter tries to load the server api key from the system settings! This key is used by backend-api-requests | `'%pimcore_system_config.services.google.simpleapikey%'` |
 
 **Example**  
 ```yaml

--- a/src/ToolboxBundle/DependencyInjection/ToolboxExtension.php
+++ b/src/ToolboxBundle/DependencyInjection/ToolboxExtension.php
@@ -31,6 +31,9 @@ class ToolboxExtension extends Extension implements PrependExtensionInterface
         if ($container->hasParameter('pimcore_system_config.services.google.browserapikey') === false) {
             $container->setParameter('pimcore_system_config.services.google.browserapikey', null);
         }
+        if ($container->hasParameter('pimcore_system_config.services.google.simpleapikey') === false) {
+            $container->setParameter('pimcore_system_config.services.google.simpleapikey', null);
+        }
 
         $selfConfigs = $container->getExtensionConfig($this->getAlias());
 

--- a/src/ToolboxBundle/Model/Document/Tag/GoogleMap.php
+++ b/src/ToolboxBundle/Model/Document/Tag/GoogleMap.php
@@ -64,7 +64,6 @@ class GoogleMap extends Document\Tag
         $configNode = $configManager->setAreaNameSpace(ConfigManagerInterface::AREABRICK_NAMESPACE_INTERNAL)->getAreaParameterConfig('googleMap');
 
         if (!empty($configNode)) {
-
             $mapOptions = $configNode['map_options'];
             $mapStyleUrl = $configNode['map_style_url'];
             $markerIcon = $configNode['marker_icon'];
@@ -210,7 +209,12 @@ class GoogleMap extends Document\Tag
         $address = urlencode($address);
 
         $key = '';
-        if (!empty($configNode) && isset($configNode['map_api_key']) && !empty($configNode['map_api_key'])) {
+        // first try to get server-api-key
+        if (!empty($configNode) && isset($configNode['simple_api_key']) && !empty($configNode['simple_api_key'])) {
+            $key = '&key=' . $configNode['simple_api_key'];
+        }
+        // if not set, get browser-api-key
+        if ($key === '' && !empty($configNode) && isset($configNode['map_api_key']) && !empty($configNode['map_api_key'])) {
             $key = '&key=' . $configNode['map_api_key'];
         }
 

--- a/src/ToolboxBundle/Resources/config/pimcore/areas/googleMap.yml
+++ b/src/ToolboxBundle/Resources/config/pimcore/areas/googleMap.yml
@@ -51,3 +51,4 @@ toolbox:
                 map_style_url: false
                 marker_icon: false
                 map_api_key: '%pimcore_system_config.services.google.browserapikey%'
+                simple_api_key: '%pimcore_system_config.services.google.simpleapikey%'

--- a/tests/bundle_tests/unit.default/Areas/GoogleMapTest.php
+++ b/tests/bundle_tests/unit.default/Areas/GoogleMapTest.php
@@ -35,15 +35,16 @@ class GoogleMapTest extends AbstractAreaTest
         $configParam = $this->getToolboxConfig()->getAreaParameterConfig('googleMap');
         $this->assertEquals(
             [
-                'map_options'   => [
+                'map_options'    => [
                     'streetViewControl' => true,
                     'mapTypeControl'    => false,
                     'panControl'        => false,
                     'scrollwheel'       => false
                 ],
-                'map_style_url' => false,
-                'marker_icon'   => false,
-                'map_api_key'   => '',
+                'map_style_url'  => false,
+                'marker_icon'    => false,
+                'map_api_key'    => '',
+                'simple_api_key' => ''
             ],
             $configParam
         );


### PR DESCRIPTION
Q | A
-- | --
Bug report? | no
Feature request? | yes
BC Break report? | no
RFC? | no

until now, the googlemaps-areabrick used the browser-api-key - since this key is usually protected by referer restrictions, the brick cannot use this key to use the geocode-api anymore

both parameters (server- and browser-api-key) from systemsettings should be available

for backwards-compatibility, if no server-api-key is set, still use browser-api-key



- [x] done as suggested