### PR TITLE
fix for issue #122

### DIFF
--- a/src/ToolboxBundle/Model/Document/Tag/ColumnAdjuster.php
+++ b/src/ToolboxBundle/Model/Document/Tag/ColumnAdjuster.php
@@ -94,4 +94,16 @@ class ColumnAdjuster extends Document\Tag
 
         return $this;
     }
+
+
+    /**
+     * @return boolean
+     *
+     * @see Document\Tag\TagInterface::isEmpty
+     *
+     */
+    public function isEmpty()
+    {
+        return ($this->data === false || !is_array($this->data) || count($this->data) === 0);
+    }
 }


### PR DESCRIPTION
- implement function isEmpty() in ColumnAdjuster-Class
| Q                | A
| ---------------- | -----
| Bug report?      | yes
| Feature request? | no
| BC Break report? | yes
| RFC?             | no

When upgrading to pimcore 6.3.3, toolbox ColumnAdjuster needs to be updated with isEmpty-function to be compliant with TagInterface