### PR TITLE
fix rendering of multiple t-col-half elements

### DIFF
--- a/src/ToolboxBundle/Resources/views/Admin/AreaConfig/fieldSet.html.twig
+++ b/src/ToolboxBundle/Resources/views/Admin/AreaConfig/fieldSet.html.twig
@@ -44,7 +44,7 @@
                     </div><!-- .col-class -->
                 </div><!-- .toolbox-element -->
 
-                {% if row_element_counter == 0 or (config_element.additional_config.col_class == 't-col-half' and row_element_counter == 2) or (config_element.additional_config.col_class == 't-col-third' and row_element_counter == 3) %}
+                {% if row_element_counter == 0 or (config_element.additional_config.col_class == 't-col-half' and row_element_counter is divisible by(2)) or (config_element.additional_config.col_class == 't-col-third' and row_element_counter is divisible by(3)) %}
                     {% set edit_mode_hidden_class = config_elements[c+1].additional_config is defined and config_elements[c+1].additional_config.editmode_hidden == true ? 'editmode-hidden' : '' %}
                     </div><div class="t-row clearfix {{ edit_mode_hidden_class }}" data-index="{{ row_counter }}">
                 {% endif %}


### PR DESCRIPTION
fixes #134

| Q             | A
| ------------- | ---
| Branch?       | 2.8 for bug fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #134 

Fixes issues when having more than 2 half-col elements or more than 3 third-col elements in the Toolbox Element Config (e.g. additionalClasses)
