### PR TITLE
Update type-asset.html.twig

### DIFF
--- a/src/ToolboxBundle/Resources/views/Toolbox/Bootstrap4/Video/type-asset.html.twig
+++ b/src/ToolboxBundle/Resources/views/Toolbox/Bootstrap4/Video/type-asset.html.twig
@@ -1,4 +1,4 @@
-<div class="player" {{ toolbox_data_attributes_generator('video_parameter', {'video_parameter' : videoParameter}, true)|raw }} data-poster-path="{{ posterPath }}" data-play-in-lightbox="{{ playInLightbox }}" data-video-uri="{{ videoId }}"></div>
+<div class="player" {{ toolbox_data_attributes_generator('video_parameter', {'video_parameter' : videoParameter}, true)|raw }} data-poster-path="{{ posterPath }}" data-play-in-lightbox="{{ playInLightbox }}" data-video-uri="{{ videoId }}">
 {{ pimcore_vhs('video', {
     'attributes': {
         'class': 'video-js vjs-default-skin vjs-big-play-centered',


### PR DESCRIPTION
Bugfix: If more than one video is added in a column, the outer div´s get closed an the HTML-markup is broken.

| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
