### PR TITLE
use no-cookie domain for youtube videos

### DIFF
--- a/src/ToolboxBundle/Resources/public/js/frontend/plugins/jquery.tb.ext.video.js
+++ b/src/ToolboxBundle/Resources/public/js/frontend/plugins/jquery.tb.ext.video.js
@@ -264,6 +264,7 @@
                             playerVars = $.extend({}, _.options.apiParameter.youtube, _.videoParameter),
                             options = {
                                 videoId: _.videoId,
+                                host: 'https://www.youtube-nocookie.com',
                                 events: {
                                     'onReady': function () {
                                         _.isReady = true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master for features / 2.8 for bug fixes
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

in order to avoid getting a youtube cookie it could be used the youtube-nocookie.com domain instead of youtube.com
