### PR TITLE
Fix wrong pimcore thumbnail class for bootstrap 3 theme

### DIFF
--- a/src/ToolboxBundle/Resources/views/toolbox/bootstrap3/image/partial/single.html.twig
+++ b/src/ToolboxBundle/Resources/views/toolbox/bootstrap3/image/partial/single.html.twig
@@ -2,6 +2,6 @@
     {{ pimcore_image('ci', { 'class' : class}) }}
 {% else %}
     {% if pimcore_image('ci').thumbnail(toolbox_get_image_thumbnail('image_element')) is not empty %}
-        {{ pimcore_image('ci', { 'class' : class}).thumbnail(toolbox_get_image_thumbnail('image_element')).html|raw }}
+        {{ pimcore_image('ci').thumbnail(toolbox_get_image_thumbnail('image_element')).html({imgAttributes: {'class' : class}})|raw }}
     {% endif %}
 {% endif %}


### PR DESCRIPTION
fixes #166

| Q             | A
| ------------- | ---
| Branch       | 4.0.4 for bug fixes
| Bug fix      | yes
| New feature  | no
| BC breaks    | no
| Deprecations? | no
| Fixed tickets | #166

Fix wrong pimcore thumbnail class for bootstrap 3 theme
