### PR TITLE
Add label for column adjuster

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,7 @@
 
 ## Version 4.0.4
 - [BUGFIX] fix file size calculation
+- [BUGFIX] add label for column adjuster [@blankse](https://github.com/dachcom-digital/pimcore-toolbox/pull/170)
 
 ## Version 4.0.3
 - [BUGFIX] return correct default value if editable is null

--- a/src/ToolboxBundle/Builder/BrickConfigBuilder.php
+++ b/src/ToolboxBundle/Builder/BrickConfigBuilder.php
@@ -282,7 +282,7 @@ class BrickConfigBuilder implements BrickConfigBuilderInterface
             'type'                       => 'columnadjuster',
             'name'                       => 'columnadjuster',
             'tab'                        => $tab,
-            'label'                      => null,
+            'label'                      => $this->translator->trans('Column adjuster', [], 'admin'),
             'config'                     => [],
             'additional_classes_element' => false,
         ];

--- a/src/ToolboxBundle/Resources/install/admin-translations/data.csv
+++ b/src/ToolboxBundle/Resources/install/admin-translations/data.csv
@@ -124,3 +124,4 @@
 "No Images for this gallery found.","No Images for this gallery found.","Es wurden keine Bilder für die Galerie gewählt.",
 "No column size selected.","No column size selected.","Keine Spaltendefinition gewählt.",
 "No downloads defined yet.","No downloads defined yet.","Keine Downloads gewählt.",
+"Column adjuster","Column adjuster","Spaltenkonfiguration",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The column adjuster in the columns brick has no label. It display only the editable name "columnadjuster":
![image](https://user-images.githubusercontent.com/998558/152651707-f7379c22-f813-4401-af7d-7e1e59fe80db.png)

