### PR TITLE
fix id for Accordion and Gallery

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
 
+## Version 4.0.6
+- [BUGFIX] fix id for Accordion and Gallery: save class names
+
 ## Version 4.0.5
 - [BUGFIX] fix type error in `Vhs:setDataFromResource`
 

--- a/src/ToolboxBundle/Document/Areabrick/Accordion/Accordion.php
+++ b/src/ToolboxBundle/Document/Areabrick/Accordion/Accordion.php
@@ -19,7 +19,7 @@ class Accordion extends AbstractAreabrick
         if (isset($infoParams['toolboxAccordionId'])) {
             $id = $infoParams['toolboxAccordionId'];
         } else {
-            $id = uniqid('accordion-', true);
+            $id = str_replace('.', '', uniqid('accordion-', true));
         }
 
         $info->setParam('id', $id);

--- a/src/ToolboxBundle/Document/Areabrick/Gallery/Gallery.php
+++ b/src/ToolboxBundle/Document/Areabrick/Gallery/Gallery.php
@@ -15,7 +15,7 @@ class Gallery extends AbstractAreabrick
         parent::action($info);
 
         $infoParams = $info->getParams();
-        $id = $infoParams['toolboxGalleryId'] ?? uniqid('gallery-', true);
+        $id = $infoParams['toolboxGalleryId'] ?? str_replace('.', '', uniqid('gallery-', true));
 
         /** @var Relations $imagesField */
         $imagesField = $this->getDocumentEditable($info->getDocument(), 'relations', 'images');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0.6
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

fix id for Accordion and Gallery: save class names (without a dot from uniqueid() with more entropy)