### PR TITLE
fix type error in DownloadExtension

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
 
+## Version 4.0.7
+- [BUGFIX] prevent type error in `DownloadExtension:getOptimizedFileSize`
+
 ## Version 4.0.6
 - [BUGFIX] fix id for Accordion and Gallery: save class names
 

--- a/src/ToolboxBundle/Twig/Extension/DownloadExtension.php
+++ b/src/ToolboxBundle/Twig/Extension/DownloadExtension.php
@@ -184,6 +184,6 @@ class DownloadExtension extends AbstractExtension
             $format = 'bytes';
         }
 
-        return round($bytes, $precision) . ' ' . $format;
+        return round((float)$bytes, $precision) . ' ' . $format;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

prevent type error in `DownloadExtension:getOptimizedFileSize`
