### PR TITLE
fix: Pimcore 10.6 compatibility

### DIFF
--- a/src/ToolboxBundle/DependencyInjection/ToolboxExtension.php
+++ b/src/ToolboxBundle/DependencyInjection/ToolboxExtension.php
@@ -137,9 +137,11 @@ class ToolboxExtension extends Extension implements PrependExtensionInterface
         $googleBrowserApiKey = null;
         $googleSimpleApiKey = null;
 
-        $pimcoreCoreConfig = $container->getParameter('pimcore.config');
-        /** @phpstan-ignore-next-line */
-        $pimcoreGoogleServiceConfig = $pimcoreCoreConfig['services']['google'] ?? [];
+        if ($container->hasParameter('pimcore.config')) {
+            $pimcoreCoreConfig = $container->getParameter('pimcore.config');
+            /** @phpstan-ignore-next-line */
+            $pimcoreGoogleServiceConfig = $pimcoreCoreConfig['services']['google'] ?? [];
+        }
 
         // browser api key
         /** @phpstan-ignore-next-line */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

This PR will make the ToolboxBundle compatible with Pimcore 10.6. Without that change, it throws a `ParameterNotFoundException`.