### PR TITLE
add asset path to thumbnail data

### DIFF
--- a/src/Service/AssetService.php
+++ b/src/Service/AssetService.php
@@ -49,6 +49,7 @@ class AssetService
             'markup'                => $thumbnail?->getHtml($options),
             'mediaList'             => $thumbnail === null ? null : $this->parseThumbnailPictureList($thumbnail, $options),
             'path'                  => $thumbnail?->getFrontendPath(),
+            'originalPath'          => $asset->getFrontendPath(),
             'lowQualityPlaceholder' => $this->parseLowQualityPlaceholder($asset),
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

This PR adds the property `originalPath` which hold the asset path for thumbnails generated via [AssetService](https://github.com/dachcom-digital/pimcore-toolbox/blob/master/src/Service/AssetService.php).