### PR TITLE
Use Pimcore AdminUserTranslator for Editable Dialog Box

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
 
+## 5.1.1
+- [BUGFIX] Use Pimcore AdminUserTranslator in BrickConfigBuilder [#219](https://github.com/dachcom-digital/pimcore-toolbox/issues/219)
+
 ## 5.1.0
 - [NEW FEATURE] Add `property_normalizer.default_type_mapping` feature
 - [ENHANCEMENT] Respect thumbnail config in normalizer

--- a/config/core_areas/parallaxContainer_service.yaml
+++ b/config/core_areas/parallaxContainer_service.yaml
@@ -2,7 +2,7 @@ services:
     ToolboxBundle\Document\ToolboxAreabrick\ParallaxContainer\ParallaxContainer:
         parent: ToolboxBundle\Document\Areabrick\AbstractAreabrick
         arguments:
-            - '@translator'
+            - '@Pimcore\Bundle\AdminBundle\Translation\AdminUserTranslator'
             - '@pimcore.templating.engine.delegating'
         tags:
             - { name: toolbox.area.brick, id: parallaxContainer }

--- a/config/services/editable.yaml
+++ b/config/services/editable.yaml
@@ -6,10 +6,14 @@ services:
         public: true
 
     ToolboxBundle\Builder\BrickConfigBuilderInterface: '@ToolboxBundle\Builder\BrickConfigBuilder'
-    ToolboxBundle\Builder\BrickConfigBuilder: ~
+    ToolboxBundle\Builder\BrickConfigBuilder:
+        arguments:
+            $translator: '@Pimcore\Bundle\AdminBundle\Translation\AdminUserTranslator'
 
     ToolboxBundle\Builder\InlineConfigBuilderInterface: '@ToolboxBundle\Builder\InlineConfigBuilder'
     ToolboxBundle\Builder\InlineConfigBuilder:
+        arguments:
+            $translator: '@Pimcore\Bundle\AdminBundle\Translation\AdminUserTranslator'
         calls:
             - [ setHeadlessEditableRenderer, [ '@ToolboxBundle\Document\Editable\HeadlessEditableRenderer' ] ]
             - [ setHeadlessEditableInfoFactory, [ '@ToolboxBundle\Factory\HeadlessEditableInfoFactory' ] ]
@@ -17,7 +21,10 @@ services:
     ToolboxBundle\Document\Editable\EditableWorker:
         public: true
 
-    ToolboxBundle\Document\Editable\ConfigParser: ~
+    ToolboxBundle\Document\Editable\ConfigParser:
+        arguments:
+            $translator: '@Pimcore\Bundle\AdminBundle\Translation\AdminUserTranslator'
+
     ToolboxBundle\Document\Editable\HeadlessEditableRenderer: ~
 
     ToolboxBundle\Factory\HeadlessEditableInfoFactory: ~

--- a/src/Builder/AbstractConfigBuilder.php
+++ b/src/Builder/AbstractConfigBuilder.php
@@ -4,7 +4,7 @@ namespace ToolboxBundle\Builder;
 
 use Pimcore\Model\Document\Editable\Area\Info;
 use Pimcore\Templating\Renderer\EditableRenderer;
-use Pimcore\Translation\Translator;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use ToolboxBundle\Document\Editable\ConfigParser;
 use ToolboxBundle\Manager\AreaManagerInterface;
 use Twig\Environment;
@@ -12,7 +12,7 @@ use Twig\Environment;
 abstract class AbstractConfigBuilder
 {
     public function __construct(
-        protected Translator $translator,
+        protected TranslatorInterface $translator,
         protected Environment $templating,
         protected AreaManagerInterface $areaManager,
         protected ConfigParser $configParser,

--- a/src/Document/Areabrick/AbstractAreabrick.php
+++ b/src/Document/Areabrick/AbstractAreabrick.php
@@ -7,8 +7,6 @@ use Pimcore\Extension\Document\Areabrick\EditableDialogBoxInterface;
 use Pimcore\Model\Document;
 use ToolboxBundle\Builder\BrickConfigBuilderInterface;
 use ToolboxBundle\Document\Response\HeadlessResponse;
-use ToolboxBundle\Event\HeadlessEditableActionEvent;
-use ToolboxBundle\ToolboxEvents;
 
 abstract class AbstractAreabrick extends AbstractBaseAreabrick implements EditableDialogBoxInterface
 {

--- a/src/Document/Editable/ConfigParser.php
+++ b/src/Document/Editable/ConfigParser.php
@@ -5,13 +5,13 @@ namespace ToolboxBundle\Document\Editable;
 use Pimcore\Model\Document\Editable\Area\Info;
 use Pimcore\Model\Document\Editable\Checkbox;
 use Pimcore\Templating\Renderer\EditableRenderer;
-use Pimcore\Translation\Translator;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use ToolboxBundle\Registry\StoreProviderRegistryInterface;
 
 class ConfigParser
 {
     public function __construct(
-        protected Translator $translator,
+        protected TranslatorInterface $translator,
         protected StoreProviderRegistryInterface $storeProvider,
         protected EditableRenderer $editableRenderer
     ) {

--- a/src/Document/ToolboxAreabrick/ParallaxContainer/ParallaxContainer.php
+++ b/src/Document/ToolboxAreabrick/ParallaxContainer/ParallaxContainer.php
@@ -5,15 +5,15 @@ namespace ToolboxBundle\Document\ToolboxAreabrick\ParallaxContainer;
 use Pimcore\Model\Asset;
 use Pimcore\Model\Document\Editable;
 use Pimcore\Model\Element\ElementInterface;
-use Pimcore\Translation\Translator;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Templating\EngineInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use ToolboxBundle\Document\Areabrick\AbstractAreabrick;
 
 class ParallaxContainer extends AbstractAreabrick
 {
     public function __construct(
-        private Translator $translator,
+        private TranslatorInterface $translator,
         private EngineInterface $templating
     ) {
     }

--- a/src/Service/DownloadInfoService.php
+++ b/src/Service/DownloadInfoService.php
@@ -3,8 +3,8 @@
 namespace ToolboxBundle\Service;
 
 use Pimcore\Model\Asset;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use ToolboxBundle\Connector\BundleConnector;
-use Pimcore\Translation\Translator;
 use ToolboxBundle\Manager\ConfigManagerInterface;
 
 class DownloadInfoService
@@ -12,7 +12,7 @@ class DownloadInfoService
     public function __construct(
         protected ConfigManagerInterface $configManager,
         protected BundleConnector $bundleConnector,
-        protected Translator $translator
+        protected TranslatorInterface $translator
     ) {
     }
 
@@ -44,7 +44,7 @@ class DownloadInfoService
         }
 
         $dType = pathinfo($download->getFilename(), PATHINFO_EXTENSION);
-        $downloadTitle = $showFileNameIfTitleEmpty ? $download->getFilename() : $this->translator->trans('Download', [], 'admin');
+        $downloadTitle = $showFileNameIfTitleEmpty ? $download->getFilename() : $this->translator->trans('Download');
         $dName = ($download->getMetadata('title')) ?: $downloadTitle;
         $dAltText = $download->getMetadata('alt') ?: '';
         $dImageAltText = !empty($dAltText) ? $dAltText : $dName;

--- a/tests/UnitDefault/Areas/AbstractAreaTest.php
+++ b/tests/UnitDefault/Areas/AbstractAreaTest.php
@@ -11,7 +11,6 @@ use Pimcore\Tests\Support\Util\TestHelper;
 use Symfony\Component\HttpFoundation\Request;
 use ToolboxBundle\Builder\BrickConfigBuilder;
 use ToolboxBundle\Manager\ConfigManager;
-use ToolboxBundle\Manager\ConfigManagerInterface;
 
 abstract class AbstractAreaTest extends BundleTestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #219 

Also:
- remove dead includes
- Download Brick: Do not use admin catalog for fallback label