### PR TITLE
[Data Attributes Generator] Output as raw HTML

### DIFF
--- a/src/Twig/Extension/DataAttributesExtension.php
+++ b/src/Twig/Extension/DataAttributesExtension.php
@@ -15,8 +15,9 @@ class DataAttributesExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('toolbox_data_attributes_generator', [$this->dataAttributeService, 'generateDataAttributes']),
+            new TwigFunction('toolbox_data_attributes_generator', [$this->dataAttributeService, 'generateDataAttributes'], [
+                'is_safe' => ['html'],
+            ]),
         ];
     }
-
 }

--- a/templates/toolbox/bootstrap4/video/type_asset.html.twig
+++ b/templates/toolbox/bootstrap4/video/type_asset.html.twig
@@ -1,4 +1,4 @@
-<div class="player" {{ toolbox_data_attributes_generator('video_parameter', {'video_parameter' : videoParameter}, true)|raw }} data-poster-path="{{ posterPath }}" data-play-in-lightbox="{{ playInLightbox }}" data-video-uri="{{ videoId }}">
+<div class="player" {{ toolbox_data_attributes_generator('video_parameter', {'video_parameter' : videoParameter}, true) }} data-poster-path="{{ posterPath }}" data-play-in-lightbox="{{ playInLightbox }}" data-video-uri="{{ videoId }}">
 {{ pimcore_vhs('video', {
     'attributes': {
         'class': 'video-js vjs-default-skin vjs-big-play-centered',

--- a/templates/toolbox/bootstrap4/video/type_vimeo.html.twig
+++ b/templates/toolbox/bootstrap4/video/type_vimeo.html.twig
@@ -1,4 +1,4 @@
-<div class="player" {{ toolbox_data_attributes_generator('video_parameter', {'video_parameter' : videoParameter}, true)|raw }} data-poster-path="{{ posterPath }}" data-play-in-lightbox="{{ playInLightbox }}" data-video-uri="{{ videoId }}"></div>
+<div class="player" {{ toolbox_data_attributes_generator('video_parameter', {'video_parameter' : videoParameter}, true) }} data-poster-path="{{ posterPath }}" data-play-in-lightbox="{{ playInLightbox }}" data-video-uri="{{ videoId }}"></div>
 {% if posterPath is not empty %}
     {% include toolbox_area_path(areaId, areaTemplateDirectory, '/partial/overlay') with {'posterPath' : posterPath, 'playInLightbox' : playInLightbox} %}
 {% endif %}

--- a/templates/toolbox/bootstrap4/video/type_youtube.html.twig
+++ b/templates/toolbox/bootstrap4/video/type_youtube.html.twig
@@ -1,4 +1,4 @@
-<div class="player" {{ toolbox_data_attributes_generator('video_parameter', {'video_parameter' : videoParameter}, true)|raw }} data-poster-path="{{ posterPath }}" data-play-in-lightbox="{{ playInLightbox }}" data-video-uri="{{ videoId }}"></div>
+<div class="player" {{ toolbox_data_attributes_generator('video_parameter', {'video_parameter' : videoParameter}, true) }} data-poster-path="{{ posterPath }}" data-play-in-lightbox="{{ playInLightbox }}" data-video-uri="{{ videoId }}"></div>
 
 {% if posterPath is not empty %}
     {% include toolbox_area_path(areaId, areaTemplateDirectory, '/partial/overlay') with {'posterPath' : posterPath, 'playInLightbox' : playInLightbox} %}

--- a/templates/toolbox/uikit3/video/type_vimeo.html.twig
+++ b/templates/toolbox/uikit3/video/type_vimeo.html.twig
@@ -9,6 +9,6 @@
             {% if autoPlay %}playsinline allow="autoplay;"{% endif %}
             data-uk-video="autoplay: true"
             width="1920" height="1080" data-uk-responsive
-            {{ toolbox_data_attributes_generator('video_parameter', {'video_parameter' : videoParameter}, true)|raw }}>
+            {{ toolbox_data_attributes_generator('video_parameter', {'video_parameter' : videoParameter}, true) }}>
     </iframe>
 {% endif %}

--- a/templates/toolbox/uikit3/video/type_youtube.html.twig
+++ b/templates/toolbox/uikit3/video/type_youtube.html.twig
@@ -9,6 +9,6 @@
             {% if autoPlay %}playsinline {% endif %}
             data-uk-video="autoplay: true"
             width="1920" height="1080" data-uk-responsive
-            {{ toolbox_data_attributes_generator('video_parameter', {'video_parameter' : videoParameter}, true)|raw }}>
+            {{ toolbox_data_attributes_generator('video_parameter', {'video_parameter' : videoParameter}, true) }}>
     </iframe>
 {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

As the data attributes generator explicitly outputs HTML code, the Twig extension also has to reflect that.

Output **before** change:
```html
data-my-attribute=&quot;my-value&quot;
```

Output **after** change:
```html
data-my-attribute="my-value"
```